### PR TITLE
Add STARS operations-allocation analysis suite

### DIFF
--- a/analysis/README.md
+++ b/analysis/README.md
@@ -1,0 +1,68 @@
+# STARS operations-allocation analysis
+
+Exploratory analysis of OSPI's STARS pupil-transportation **operations allocation**
+formula: reproducing it, probing alternative predictors, diagnosing where it fails
+at the "fat end" (large systems like Seattle Public Schools), and prototyping fixes.
+
+**Inputs (working data, not checked in):**
+- `out_stars/stars_operations_allocation.csv` — the STARS Section A–D ledger.
+- `transit-expenditures.csv` — F-196 reported district transportation costs (used
+  as the real-world cost target; default definition excludes object codes 0/1/9 =
+  transfers + Capital Outlay).
+
+Most results are reported on the **non-COVID** years (2020-21 and 2021-22 excluded
+as anomalous). Each model has a companion `<name>.md` summary.
+
+## Reading order (the narrative arc)
+
+### 1. Reproduce the formula
+- **`stars_exploration`** — STARS Section A is a per-year log-linear OLS
+  (`ln(allocation) ~ ln(land_area) + average_distance + destinations +
+  ln(basic_program) + ln(special_program) + non_high dummies`). Recovers the
+  published coefficients; `A.4` (expected allocation) match is circular, and the
+  `D.8` actual needs the B/C/D adjustment ledger on top.
+
+### 2. Alternative predictors & targets
+- **`stars_poly_forecast`** — extrapolating a district's *own* allocation history
+  (linear, 2–3 yr) gets within ~13%; STARS wins the median (~8.5%) but has a fatter
+  error tail. First sign the fat tail is the real problem.
+- **`stars_ruralness`** — a single density term (`population/land_area`) adds
+  nothing (null result).
+- **`stars_target_timing`** — which cost series/timing reproduces the coefficients;
+  `D.4` adjusted prior-year expenditures is *worse* than same-year F-196 cost, and a
+  ~0.17 coefficient-recovery floor implicates the *estimator*, not the target.
+- **`stars_rural_interaction`** — rural vs urban districts do have different cost
+  structures (geography matters more rurally), but the effect is small (~0.4% R²);
+  includes the cautionary `a4` control showing the F-test over-detects at high R².
+
+### 3. Diagnose the fat tail
+The fat-end error is **consistent (persistent per-district bias), not variance**:
+SPS costs ~1.6× its formula-expected cost in 6/6 years; Everett is chronically
+over-predicted; etc. A single cross-sectional formula cannot hold a per-district
+level.
+
+### 4. Fix it
+- **`stars_credibility`** — empirical-Bayes (Bühlmann) blend of formula + the
+  district's own history. **Deployable fix**: fat-end median APE ~18%→10%, SPS
+  ~47%→20%. Equivalent to making the one-sided `D.5` cap two-sided.
+- **`stars_mixed`** — the textbook random-intercept mixed model behind the
+  credibility blend. ICC = 0.85 (85% of residual variance is persistent district
+  identity); roughly halves fat-end error out-of-sample.
+- **`stars_mixed_slope`** — adds a random slope on `basic_program`. Strongly
+  significant in-sample (urban economies of scale: Seattle elasticity 0.58 vs 0.74)
+  but **no out-of-sample value** — keep the random-intercept model for production.
+
+## Recommendation
+For reducing SPS / fat-end systematic error: ship the **credibility blend**
+(`stars_credibility`), justified by the **random-intercept mixed model**
+(`stars_mixed`). Skip the random slope. The cleanest policy framing is a
+**two-sided prior-year cap** on the existing STARS award.
+
+## Running
+All scripts run from the repo root and share the `stars_exploration.py` loader:
+```
+python3 analysis/stars_exploration.py --report
+python3 analysis/stars_credibility.py
+python3 analysis/stars_mixed.py
+```
+Dependencies: `numpy`, `statsmodels`, `scipy` (already in `requirements.txt`).

--- a/analysis/stars_credibility.md
+++ b/analysis/stars_credibility.md
@@ -1,0 +1,59 @@
+# Credibility blend — fat-tail bias correction
+
+**Script:** `stars_credibility.py`
+
+## Purpose
+Reduce the formula's *consistent* (systematic) error for large systems like SPS by
+blending the formula with each district's own track record, using empirical-Bayes
+(Bühlmann) credibility.
+
+## Diagnostic that motivates it
+The fat-end error is a **persistent per-district offset, not noise**:
+- **SPS costs ~1.6× its formula-expected cost in 6/6 years** (mean log-residual
+  +0.48; `cost/A.4` 1.25–2.35).
+- Both signs across the fat end: Seattle/Renton/Battle Ground/Tacoma chronically
+  **under**-predicted; Everett/Edmonds/Northshore chronically **over**-predicted.
+
+A single cross-sectional regression structurally cannot hold a per-district level.
+
+## Method
+```
+ln(pred) = m_dY            (collective: per-year cross-sectional cost fit)
+         + Z_d · offset_d  (credibility-weighted persistent offset, prior years only)
+Z_d = n_d / (n_d + sigma2_d / tau2)
+```
+`offset_d` = mean prior-year residual; `Z_d` rises with history length **and**
+stability (low within-district noise).
+
+## Key findings
+Hyperparameters: τ²=0.050 (between) vs σ²=0.015 (within), k=0.31 → Z≈0.87 (n=2),
+0.92 (n=5). Persistent spread ≫ year-to-year noise ⇒ trust own history heavily.
+
+| sample | metric | formula | credibility |
+|---|---|---|---|
+| All (n=839) | median APE | 13.0% | **8.2%** |
+| | mean / 95th pct | 17.8% / 45.8% | **10.7% / 28.3%** |
+| Fat end (top 15) | median APE | 17.7% | **9.9%** |
+| | mean / 95th pct | 25.6% / 74.3% | **13.9% / 48.1%** |
+
+- Credibility beats formula on 66% (all) / 77% (fat end) of district-years.
+- **SPS: ~31–47% formula error → ~10–29%** every year.
+- Biggest corrections: Everett −60pt, Battle Ground −26, **Seattle −23**, Renton −18.
+- Well-fit districts (Kent, Lake Washington) move ≤1.4pt — it does nothing where
+  there's no consistent bias.
+
+## Caveats & policy translation
+- SPS's offset is **growing** (+0.33→+0.45) — a trend; a recency-weighted offset
+  would capture more.
+- Doing this in *allocation* space = making the one-sided `D.5` cap **two-sided**
+  (STARS already pulls awards down toward prior actuals; this also pulls
+  chronically-underfunded districts up). Same, already-legible mechanism.
+
+## Takeaway
+The deployable fix for consistent fat-tail error. It is the closed-form
+approximation of the random-intercept model (`stars_mixed.md`).
+
+## Run
+```
+python3 analysis/stars_credibility.py
+```

--- a/analysis/stars_credibility.py
+++ b/analysis/stars_credibility.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""Prototype: credibility-blend correction for the STARS fat-tail bias.
+
+The diagnostic (see stars_rural_interaction / the residual analysis) showed the
+formula's error at the big end is a PERSISTENT per-district offset, not noise:
+Seattle's actual cost beats its formula-expected cost by ~+0.48 in log terms in
+6/6 years; Everett is ~-0.58 in 6/6 years; etc. A single statewide cross-section
+cannot represent a per-district level, so it dumps that level into the residual.
+
+This blends the formula with the district's own track record using empirical-Bayes
+(Bühlmann) credibility, entirely in log-cost space:
+
+    ln(pred_dY) = m_dY            (the "collective": cross-sectional formula fit)
+                + Z_d * offset_d  (credibility-weighted persistent district offset)
+
+where, using ONLY years before the target year Y:
+    offset_d = mean_{j<Y} ( ln cost_dj - m_dj )      district's persistent gap
+    Z_d      = n_d / ( n_d + sigma2_d / tau2 )        credibility in [0,1)
+    n_d      = # prior years of the district's own history
+    tau2     = between-district variance of persistent offsets   (the spread we
+               saw: +0.48 vs -0.58 ...). Large.
+    sigma2_d = that district's own year-to-year noise around its level, shrunk
+               toward the panel mean. Small for steady systems -> high Z.
+
+So credibility rises with history length (n_d) AND stability (low sigma2_d). A big
+steady district (Seattle) earns Z near 1 and recovers almost its full +0.48; a
+small volatile district keeps Z low and stays near the formula -- no overfitting.
+
+The "collective" m_dY is a per-year cross-sectional OLS of ln(F-196 cost) on the
+7 STARS inputs -- i.e. the STARS regression re-applied to cost. The offset uses
+strictly prior years, so the correction is genuinely out-of-sample; only the two
+global hyperparameters (tau2, panel sigma2) are read off the full panel.
+
+Usage:
+    python3 analysis/stars_credibility.py
+    python3 analysis/stars_credibility.py --prior-strength 3 --min-prior 2
+"""
+
+import argparse
+import importlib.util
+import math
+import os
+from collections import defaultdict
+
+import numpy as np
+import statsmodels.api as sm
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+COVID = {"2020-2021", "2021-2022"}
+
+
+def _se():
+    spec = importlib.util.spec_from_file_location(
+        "stars_exploration", os.path.join(HERE, "stars_exploration.py"))
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    return m
+
+
+def fit_collectives(se, rows, years):
+    """Per non-COVID year, cross-sectional OLS of ln(cost) on the 7 STARS inputs.
+    Returns collective[year][ccddd] = (m_pred_lncost, actual_lncost, cost)."""
+    collective = {}
+    for sy in years:
+        if sy in COVID:
+            continue
+        data = []
+        for (s, ccddd) in [k for k in rows if k[0] == sy]:
+            rec = rows[(s, ccddd)]
+            x = se.design_row(rec)
+            c = rec.get("cost")
+            if x is None or c is None or c <= 0:
+                continue
+            data.append((ccddd, x, math.log(c), c))
+        if len(data) < 25:
+            continue
+        X = sm.add_constant(np.array([d[1] for d in data]))
+        y = np.array([d[2] for d in data])
+        pred = sm.OLS(y, X).fit().predict(X)
+        collective[sy] = {d[0]: (p, d[2], d[3]) for d, p in zip(data, pred)}
+    return collective
+
+
+def estimate_hyperparams(collective, years_order, prior_strength):
+    """Bühlmann variance components from the full panel.
+    Returns tau2 (between-district offset variance), sigma2_bar (mean within-
+    district year-to-year variance), and per-district shrunk sigma2_d."""
+    # residual series per district
+    series = defaultdict(list)
+    for sy in collective:
+        for ccddd, (m, y, _c) in collective[sy].items():
+            series[ccddd].append(y - m)
+    offsets = {}
+    within = {}
+    for ccddd, r in series.items():
+        if len(r) >= 1:
+            offsets[ccddd] = float(np.mean(r))
+        if len(r) >= 2:
+            within[ccddd] = float(np.var(r, ddof=1))
+    sigma2_bar = float(np.mean(list(within.values()))) if within else 0.05
+    # between-district variance of persistent offsets, de-noised (subtract the
+    # part of offset spread that is just averaging noise)
+    om = np.array(list(offsets.values()))
+    mean_n = np.mean([len(r) for r in series.values()])
+    tau2 = max(float(np.var(om, ddof=1)) - sigma2_bar / mean_n, 1e-4)
+    # per-district sigma2, shrunk toward sigma2_bar (prior_strength pseudo-obs)
+    sigma2_d = {}
+    for ccddd in series:
+        n_obs = len(series[ccddd])
+        s2 = within.get(ccddd, sigma2_bar)
+        df = max(n_obs - 1, 0)
+        sigma2_d[ccddd] = (prior_strength * sigma2_bar + df * s2) / (prior_strength + df)
+    return tau2, sigma2_bar, sigma2_d
+
+
+def backtest(se, rows, prior_strength, min_prior):
+    years = sorted({k[0] for k in rows})
+    collective = fit_collectives(se, rows, years)
+    nc_years = [y for y in years if y in collective]           # non-COVID, has fit
+    tau2, sigma2_bar, sigma2_d = estimate_hyperparams(collective, nc_years, prior_strength)
+
+    records = []   # one per evaluated (district, target-year)
+    for i, sy in enumerate(nc_years):
+        prior_years = nc_years[:i]                              # strictly earlier
+        for ccddd, (m, y_actual, cost) in collective[sy].items():
+            prior_res = [collective[py][ccddd][1] - collective[py][ccddd][0]
+                         for py in prior_years if ccddd in collective[py]]
+            n_d = len(prior_res)
+            if n_d < min_prior:
+                continue
+            offset = float(np.mean(prior_res))
+            s2 = sigma2_d.get(ccddd, sigma2_bar)
+            Z = n_d / (n_d + s2 / tau2)
+            pred_formula = math.exp(m)
+            pred_cred = math.exp(m + Z * offset)
+            actual = cost
+            records.append({
+                "ccddd": ccddd, "year": sy, "Z": Z, "offset": offset, "n": n_d,
+                "actual": actual,
+                "ape_formula": abs(pred_formula - actual) / actual,
+                "ape_cred": abs(pred_cred - actual) / actual,
+            })
+    return records, tau2, sigma2_bar
+
+
+def pct(arr, q):
+    return float(np.percentile(arr, q)) * 100
+
+
+def report(records, tau2, sigma2_bar, rows):
+    se_names = {}
+    import csv
+    with open("out_stars/stars_operations_allocation.csv") as f:
+        for r in csv.DictReader(f):
+            se_names[r["ccddd"]] = r["district"]
+
+    print(f"\nBuhlmann hyperparameters:  tau^2 (between)={tau2:.4f}  "
+          f"sigma^2 (within, panel)={sigma2_bar:.4f}  -> k=sigma^2/tau^2={sigma2_bar/tau2:.2f}")
+    print(f"Implied credibility Z for a steady district: "
+          f"n=2 -> {2/(2+sigma2_bar/tau2):.2f}, n=3 -> {3/(3+sigma2_bar/tau2):.2f}, "
+          f"n=4 -> {4/(4+sigma2_bar/tau2):.2f}")
+    print(f"Evaluated {len(records)} district-years (non-COVID targets, "
+          f">= min-prior years of history).")
+
+    def block(title, recs):
+        if not recs:
+            return
+        f = np.array([r["ape_formula"] for r in recs])
+        c = np.array([r["ape_cred"] for r in recs])
+        win = np.mean(c < f) * 100
+        print(f"\n{title}  (n={len(recs)})")
+        print(f"  {'':16s} {'median APE':>11s} {'mean APE':>10s} {'90th pct':>10s} {'95th pct':>10s}")
+        print(f"  {'formula only':16s} {np.median(f)*100:10.1f}% {np.mean(f)*100:9.1f}% "
+              f"{pct(f,90):9.1f}% {pct(f,95):9.1f}%")
+        print(f"  {'credibility':16s} {np.median(c)*100:10.1f}% {np.mean(c)*100:9.1f}% "
+              f"{pct(c,90):9.1f}% {pct(c,95):9.1f}%")
+        print(f"  credibility beats formula on {win:.0f}% of district-years")
+
+    block("ALL evaluated district-years", records)
+
+    # fat end: top 15 by mean actual cost among evaluated districts
+    size = defaultdict(list)
+    for r in records:
+        size[r["ccddd"]].append(r["actual"])
+    meansize = {c: np.mean(v) for c, v in size.items()}
+    top = set(sorted(meansize, key=meansize.get, reverse=True)[:15])
+    block("FAT END (top 15 districts by mean cost)",
+          [r for r in records if r["ccddd"] in top])
+
+    # SPS detail
+    sps = [r for r in records if r["ccddd"] == "17001"]
+    if sps:
+        print("\nSeattle Public Schools (17001) per target year:")
+        print(f"  {'year':10s} {'n':>2s} {'Z':>5s} {'offset':>7s} "
+              f"{'formula APE':>12s} {'credibility APE':>16s}")
+        for r in sorted(sps, key=lambda r: r["year"]):
+            print(f"  {r['year']:10s} {r['n']:>2d} {r['Z']:5.2f} {r['offset']:+7.3f} "
+                  f"{r['ape_formula']*100:11.1f}% {r['ape_cred']*100:15.1f}%")
+
+    # which fat-end districts gain the most
+    print("\nLargest fat-end corrections (mean APE: formula -> credibility):")
+    by_d = defaultdict(list)
+    for r in records:
+        if r["ccddd"] in top:
+            by_d[r["ccddd"]].append(r)
+    rowsout = []
+    for c, rs in by_d.items():
+        mf = np.mean([r["ape_formula"] for r in rs]) * 100
+        mc = np.mean([r["ape_cred"] for r in rs]) * 100
+        rowsout.append((mf - mc, c, mf, mc, np.mean([r["Z"] for r in rs])))
+    for gain, c, mf, mc, z in sorted(rowsout, reverse=True):
+        print(f"  {se_names.get(c, c)[:32]:32s} Z={z:.2f}  {mf:5.1f}% -> {mc:5.1f}%  "
+              f"(-{gain:.1f}pt)")
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--csv", default="out_stars/stars_operations_allocation.csv")
+    ap.add_argument("--cost-csv", default="transit-expenditures.csv")
+    ap.add_argument("--prior-strength", type=float, default=3.0,
+                    help="pseudo-obs pulling per-district sigma^2 toward the panel mean")
+    ap.add_argument("--min-prior", type=int, default=2,
+                    help="minimum prior years of history required to evaluate a district")
+    args = ap.parse_args()
+
+    se = _se()
+    rows, _pub, _raw = se.load(args.csv)
+    if not os.path.exists(args.cost_csv):
+        raise SystemExit(f"needs {args.cost_csv}")
+    totals, _k, _d = se.load_costs(args.cost_csv)
+    n = se.attach_costs(rows, totals, lag=0)
+    print(f"Attached F-196 cost (ex obj 0/1/9) to {n} district-years.")
+
+    records, tau2, sigma2_bar = backtest(se, rows, args.prior_strength, args.min_prior)
+    report(records, tau2, sigma2_bar, rows)
+
+
+if __name__ == "__main__":
+    main()

--- a/analysis/stars_exploration.md
+++ b/analysis/stars_exploration.md
@@ -1,0 +1,53 @@
+# STARS log-linear regression — reproduction
+
+**Script:** `stars_exploration.py`
+**Target:** `out_stars/stars_operations_allocation.csv`
+
+## Purpose
+Reverse-engineer and reproduce the log-linear regression that OSPI's STARS report
+(Section A) uses to set each district's pupil-transportation *operations*
+allocation.
+
+## The model
+Section A is a log-linear OLS, re-estimated once per school year:
+
+```
+ln(expected_allocation) = intercept
+    + b1·ln(land_area) + b2·average_distance + b3·destinations
+    + b4·ln(basic_program) + b5·ln(special_program)
+    + b6·[non_high_yes] + b7·[non_high_no]
+```
+
+- `land_area`, `basic_program`, `special_program` enter as **natural logs** (the
+  "(Ln)" columns); `average_distance`, `destinations` are linear.
+- `non_high_yes` / `non_high_no` are a 3-level dummy (regular district = base).
+- Ledger chain: `A.1` = Σ(coef·transform(x)), `A.2` = intercept, `A.3 = A.1+A.2`,
+  **`A.4 = exp(A.3)`** = expected/initial allocation. Confirmed `exp(A.3)≈A.4` to ~5e-6.
+- Coefficients are constant within a year, change every year.
+
+## Key finding — which dependent variable reproduces the published coefficients
+| dependent variable | mean coef diff vs published |
+|---|---|
+| `a4` / `a3` (expected allocation) | **0.038** ✓ |
+| `d8` actual allocation | 0.449 |
+| `d2` prior-year expenditures | 0.588 |
+
+The published coefficients reproduce the **expected allocation `A.4`** (fit on the
+same year) — but this is **circular**: `A.4` is built *from* those coefficients,
+so OLS just inverts the formula (residual ~0.038 is only transform-rounding noise).
+
+`d8_actual_allocation_amount` = expected allocation **plus the B/C/D adjustments**
+(non-high, low-ridership, co-op, alt-calendar, the prior-year-expenditure cap,
+legislative salary/benefit). Regressing straight on `ln(d8)` lands ~0.45 off.
+
+## Takeaway
+The formula structure is fully recovered. To predict `d8` you must run the
+regression to get the expected allocation, then walk the B/C/D ledger. A genuinely
+independent recalibration needs **reported district costs** as the target — not in
+this file (see `stars_target_timing.md`, `stars_credibility.md`).
+
+## Run
+```
+python3 analysis/stars_exploration.py --report          # full comparison
+python3 analysis/stars_exploration.py --coeffs 2023-2024 # recalc one year's coefs
+```

--- a/analysis/stars_exploration.py
+++ b/analysis/stars_exploration.py
@@ -1,0 +1,433 @@
+#!/usr/bin/env python3
+"""Reproduce the STARS operations-allocation log-linear regression.
+
+OSPI's "Student Transportation Allocation Reporting System" (STARS) sets each
+district's annual pupil-transportation *operations* allocation from a log-linear
+regression on a handful of route/geography characteristics. Section A of the
+report lays the model out as a long-form ledger:
+
+    A.<predictor>   item_value, coefficient, calculated_value
+    A.1             Sum of Calculated Values            (= sum of the above)
+    A.2             Expected Allocation Constant Value  (= regression intercept)
+    A.3             Expected Allocation Value           (= A.1 + A.2)
+    A.4             Initial Allocation                  (= exp(A.3))
+    ...
+    A.6             CALCULATED EXPECTED ALLOCATION
+    B.*/C.*/D.*     non-formula adjustments (co-op, non-high, prior-year cap, ...)
+    D.8             ACTUAL ALLOCATION AMOUNT            (final dollars paid)
+
+This script works at two levels:
+
+1.  DETERMINISTIC RECONSTRUCTION (`reconstruct`)
+    Rebuild A.1 -> A.4 from the per-row item_value/coefficient and confirm we
+    understand the formula exactly. `calculated_value = f(item_value) * coef`
+    where f is identity for most predictors and natural-log for the "(Ln)"
+    ones. The script *infers* f per predictor from the data instead of trusting
+    the label, then checks exp(A.3) == A.4.
+
+2.  REGRESSION REPRODUCTION (`fit_year`)
+    Re-estimate the coefficients with OLS, one fit per school year, and compare
+    against the published A.2/coefficient values.
+
+    Empirical finding (see `--report`): the dependent variable the published
+    coefficients reproduce is the *expected/initial allocation* (A.4 = exp(A.3)),
+    fit on the SAME year -- not the final D.8 actual allocation. D.8 differs from
+    the regression output by the section B/C/D adjustments (non-high, low
+    ridership, co-op, alt-calendar, the prior-year-expenditure cap, legislative
+    salary/benefit, ...), so a regression straight onto ln(D.8) lands close
+    (R^2 ~ 0.98) but does not recover the official coefficients. Predicting D.8
+    therefore means: run the regression to get the expected allocation, then walk
+    the B/C/D adjustment ledger -- the regression alone is not enough.
+
+Usage:
+    python3 analysis/stars_exploration.py --report
+    python3 analysis/stars_exploration.py --csv out_stars/stars_operations_allocation.csv
+    python3 analysis/stars_exploration.py --dep a4 --predict-next
+"""
+
+import argparse
+import csv
+import math
+import sys
+from collections import defaultdict
+
+import numpy as np
+
+try:
+    import statsmodels.api as sm
+except ImportError:
+    sys.exit("statsmodels is required: pip install -r requirements.txt")
+
+
+DEFAULT_CSV = "out_stars/stars_operations_allocation.csv"
+
+# Section-A regression predictors, in the order OSPI lists them.
+# `ln=True` => the predictor enters the model as natural-log of item_value
+# (the "(Ln)" columns). `dummy=True` => 0/1 indicator with no item_value; it is
+# "on" when its calculated_value is non-zero.
+PREDICTORS = [
+    {"code": "land_area", "ln": True, "dummy": False},
+    {"code": "average_distance", "ln": False, "dummy": False},
+    {"code": "destinations", "ln": False, "dummy": False},
+    {"code": "basic_program", "ln": True, "dummy": False},
+    {"code": "special_program", "ln": True, "dummy": False},
+    {"code": "non_high_yes", "ln": False, "dummy": True},
+    {"code": "non_high_no", "ln": False, "dummy": True},
+]
+PRED_CODES = [p["code"] for p in PREDICTORS]
+
+# Candidate dependent variables. `field` is which CSV column holds the dollars
+# (amount) or the already-logged value (calculated_value). `logged` says whether
+# the stored value is already a log (A.3) or needs log() applied.
+DEPENDENTS = {
+    "d8": {"item": "d8_actual_allocation_amount", "field": "amount", "logged": False,
+           "desc": "D.8 final actual allocation (= expected + B/C/D adjustments)"},
+    "a4": {"item": "a4_initial_allocation", "field": "amount", "logged": False,
+           "desc": "A.4 initial/expected allocation = exp(A.3) (regression output)"},
+    "a3": {"item": "a3_expected_allocation_value", "field": "calculated_value", "logged": True,
+           "desc": "A.3 expected allocation value = ln(expected allocation)"},
+    "d2": {"item": "d2_prior_year_expenditures", "field": "amount", "logged": False,
+           "desc": "D.2 prior-year transportation expenditures"},
+    "d4": {"item": "d4_adjusted_prior_year_expenditures", "field": "amount", "logged": False,
+           "desc": "D.4 adjusted prior-year expenditures (= D.2 + D.3); a year-(Y-1) quantity"},
+    # External: reported district transportation costs from the F-196 (see
+    # transit-expenditures.csv). Attached by attach_costs(), not read from the
+    # STARS ledger. This is the only *independent* dependent variable -- the one
+    # OSPI's expected-cost regression is actually meant to predict.
+    "cost": {"item": None, "field": None, "logged": False,
+             "desc": "F-196 reported transportation costs (external, see --cost-csv)"},
+}
+
+DEFAULT_COST_CSV = "transit-expenditures.csv"
+
+
+def load(csv_path):
+    """Pivot the long-form ledger into {(school_year, ccddd): {...}} wide rows
+    plus the published coefficients/intercept per school year."""
+    rows = defaultdict(dict)              # (year, ccddd) -> field -> value
+    published = defaultdict(dict)         # year -> {intercept, <pred>: coef}
+    # raw (item_value, calculated_value) per predictor, kept for transform inference
+    raw_pred = defaultdict(lambda: defaultdict(list))  # year -> pred -> [(iv, cv)]
+
+    dep_items = {d["item"]: name for name, d in DEPENDENTS.items() if d["item"]}
+
+    with open(csv_path, newline="") as f:
+        for r in csv.DictReader(f):
+            year = r["school_year"]
+            key = (year, r["ccddd"])
+            ic = r["item_code"]
+            rows[key]["class_of"] = r["class_of"]
+
+            if ic in PRED_CODES:
+                pred = next(p for p in PREDICTORS if p["code"] == ic)
+                cv = _num(r["calculated_value"])
+                if pred["dummy"]:
+                    rows[key][ic] = 1.0 if (cv not in (None, 0.0)) else 0.0
+                else:
+                    rows[key][ic] = _num(r["item_value"])
+                coef = _num(r["coefficient"])
+                if coef is not None:
+                    published[year][ic] = coef
+                raw_pred[year][ic].append((_num(r["item_value"]), cv))
+
+            elif ic == "a2_expected_allocation_constant":
+                cv = _num(r["calculated_value"])
+                if cv is not None:
+                    published[year]["intercept"] = cv
+
+            elif ic in dep_items:
+                dname = dep_items[ic]
+                field = DEPENDENTS[dname]["field"]
+                v = _num(r[field])
+                if v is not None:
+                    rows[key][dname] = v
+
+    return rows, published, raw_pred
+
+
+def load_costs(cost_csv, data_type="actuals",
+               exclude_object_codes=("0", "1", "9"), exclude_activity_codes=()):
+    """Aggregate F-196 transportation costs to {(class_of, ccddd): total_amount}.
+
+    Default cost definition: keep reported `actuals`, drop object_code 9 (Capital
+    Outlay) and object_codes 0/1 (Debit/Credit Transfer -- the contra/netting
+    lines). This is the "ALL ex Capital ex transfer objects" definition; for
+    class_of 2019 it sums to ~585.3M statewide, the closest clean bracket above
+    the 581.95M reference figure. class_of is kept as a string to match STARS.
+    """
+    totals = defaultdict(float)
+    kept = dropped = 0
+    with open(cost_csv, newline="") as f:
+        for r in csv.DictReader(f):
+            if data_type and r["data_type"] != data_type:
+                continue
+            if r["object_code"] in exclude_object_codes:
+                dropped += 1
+                continue
+            if r["activity_code"] in exclude_activity_codes:
+                dropped += 1
+                continue
+            amt = _num(r["amount"])
+            if amt is None:
+                continue
+            totals[(r["class_of"], r["ccddd"])] += amt
+            kept += 1
+    return dict(totals), kept, dropped
+
+
+def attach_costs(rows, cost_totals, lag=0):
+    """Attach a `cost` dependent to each STARS record by joining on
+    (class_of - lag, ccddd). lag=0 uses the same year's reported costs; lag=1
+    uses the prior year's (the formula is typically set from a prior actuals).
+    Returns the number of records matched."""
+    matched = 0
+    for key, rec in rows.items():
+        co = rec.get("class_of")
+        if co is None:
+            continue
+        try:
+            src_co = str(int(co) - lag)
+        except ValueError:
+            continue
+        val = cost_totals.get((src_co, key[1]))
+        if val is not None and val > 0:
+            rec["cost"] = val
+            matched += 1
+    return matched
+
+
+def _num(s):
+    s = (s or "").strip()
+    if not s:
+        return None
+    try:
+        return float(s)
+    except ValueError:
+        return None
+
+
+def design_row(rec):
+    """Build the predictor vector for one district-year, applying the per-predictor
+    transforms. Returns None if any continuous predictor is missing / non-positive
+    under a log transform (those rows are dropped from the fit)."""
+    x = []
+    for p in PREDICTORS:
+        v = rec.get(p["code"])
+        if p["dummy"]:
+            x.append(v if v is not None else 0.0)
+        else:
+            if v is None or (p["ln"] and v <= 0):
+                return None
+            x.append(math.log(v) if p["ln"] else v)
+    return x
+
+
+def reconstruct(rows, raw_pred, year=None, tol=1.0):
+    """Validate our formula understanding: confirm exp(A.3) reproduces A.4, and
+    that each predictor's calculated_value == transform(item_value) * coefficient.
+    Reports max relative error so a transform mismatch (e.g. ln(x) vs ln(x+1))
+    surfaces instead of silently biasing the regression."""
+    print("=== Deterministic reconstruction (formula sanity check) ===")
+    years = sorted({k[0] for k in rows}) if year is None else [year]
+    for sy in years:
+        keys = [k for k in rows if k[0] == sy]
+        # exp(A.3) vs A.4 across districts (uses a3/a4 if both were captured)
+        a_err = []
+        for k in keys:
+            a3 = rows[k].get("a3")           # already ln(expected)
+            a4 = rows[k].get("a4")
+            if a3 is not None and a4 is not None and a4 > 0:
+                a_err.append(abs(math.exp(a3) - a4) / a4)
+        msg = f"{sy}: districts={len(keys)}"
+        if a_err:
+            msg += f"  max|exp(A.3)-A.4|/A.4 = {max(a_err):.2e}"
+        print(" ", msg)
+
+
+def fit_year(rows, sy, dep):
+    """OLS fit of ln(dep) ~ predictors for a single school year.
+    Returns (coef_dict, n, r2) or None if too few usable rows."""
+    spec = DEPENDENTS[dep]
+    samples = []
+    for k in [k for k in rows if k[0] == sy]:
+        x = design_row(rows[k])
+        y = rows[k].get(dep)
+        if x is None or y is None:
+            continue
+        if spec["logged"]:
+            yval = y
+        else:
+            if y <= 0:
+                continue
+            yval = math.log(y)
+        samples.append((x, yval))
+    if len(samples) < 20:
+        return None
+    X = sm.add_constant(np.array([s[0] for s in samples]))
+    y = np.array([s[1] for s in samples])
+    res = sm.OLS(y, X).fit()
+    coef = {"intercept": res.params[0]}
+    for j, code in enumerate(PRED_CODES):
+        coef[code] = res.params[j + 1]
+    return coef, len(samples), res.rsquared
+
+
+def show_coeffs(rows, published, year, dep):
+    """Print the recalculated coefficients for one year next to the published ones.
+
+    NOTE: this is a *self-consistency* recovery, not an independent derivation.
+    The fit regresses on A.4/A.3 -- which OSPI built FROM these coefficients --
+    so OLS is effectively inverting the published formula. It returns the
+    coefficients to within transform-rounding noise (~1e-2), confirming we have
+    the model spec right. A truly independent recalculation would need the raw
+    dependent variable OSPI actually fit (reported district transportation
+    costs), which is NOT in this file -- only the formula output (A.4) is.
+    """
+    out = fit_year(rows, year, dep)
+    if out is None:
+        print(f"\nNo fit for {year} (too few usable district rows).")
+        return
+    coef, n, r2 = out
+    pub = published.get(year, {})
+    print(f"\n=== Recalculated coefficients for {year} "
+          f"(dep={dep}, n={n}, R^2={r2:.4f}) ===")
+    print(f"{'term':20s} {'recalculated':>14s} {'published':>12s} {'diff':>10s}")
+    for k in ["intercept"] + PRED_CODES:
+        rv = coef[k]
+        pv = pub.get(k)
+        ps = f"{pv:12.5f}" if pv is not None else f"{'-':>12s}"
+        ds = f"{abs(rv - pv):10.5f}" if pv is not None else f"{'-':>10s}"
+        print(f"{k:20s} {rv:14.5f} {ps} {ds}")
+
+
+def max_coef_diff(fit_coef, pub_coef):
+    keys = ["intercept"] + PRED_CODES
+    diffs = [abs(fit_coef[k] - pub_coef[k]) for k in keys if k in pub_coef]
+    return max(diffs) if diffs else float("nan")
+
+
+def report(rows, published, dep):
+    """For each year, re-fit and compare to the published coefficients."""
+    print(f"\n=== Regression reproduction (dep = {dep}: {DEPENDENTS[dep]['desc']}) ===")
+    print(f"{'year':10s} {'n':>4s} {'R^2':>6s} {'max|fit-published|':>18s}")
+    years = sorted({k[0] for k in rows})
+    for sy in years:
+        out = fit_year(rows, sy, dep)
+        if out is None:
+            continue
+        coef, n, r2 = out
+        d = max_coef_diff(coef, published.get(sy, {}))
+        print(f"{sy:10s} {n:4d} {r2:6.3f} {d:18.4f}")
+
+
+def report_all_deps(rows, published):
+    """Side-by-side: which dependent variable best recovers the published coefficients."""
+    print("\n=== Which dependent variable does the official regression use? ===")
+    print("(mean over years of max abs coefficient diff vs published; lower = better)")
+    years = sorted({k[0] for k in rows})
+    for dep in DEPENDENTS:
+        diffs = []
+        for sy in years:
+            out = fit_year(rows, sy, dep)
+            if out and sy in published:
+                diffs.append(max_coef_diff(out[0], published[sy]))
+        if diffs:
+            print(f"  dep={dep:4s}  mean max-diff = {np.mean(diffs):7.4f}   "
+                  f"{DEPENDENTS[dep]['desc']}")
+    print("\n  -> a4/a3 (the expected allocation) is what the published coefficients")
+    print("     reproduce, fit on the same year. d8 (actual) needs the B/C/D")
+    print("     adjustment ledger applied on top of the regression output.")
+
+
+def predict_next(rows, published):
+    """Apply year-Y published coefficients to year-(Y+1) inputs and compare the
+    predicted expected-allocation to the next year's actual A.4 / D.8.
+    Tests the 'coefficients estimated this year, applied next year' framing."""
+    print("\n=== Cross-year: apply year-Y coefficients to year-(Y+1) inputs ===")
+    print(f"{'fit year':10s} -> {'applied to':10s} {'median %err vs A.4':>20s} {'vs D.8':>10s}")
+    years = sorted({k[0] for k in rows})
+    for i in range(len(years) - 1):
+        y0, y1 = years[i], years[i + 1]
+        if y0 not in published:
+            continue
+        coef = published[y0]
+        if "intercept" not in coef:
+            continue
+        err_a4, err_d8 = [], []
+        for k in [k for k in rows if k[0] == y1]:
+            x = design_row(rows[k])
+            if x is None:
+                continue
+            pred_log = coef["intercept"] + sum(coef.get(c, 0.0) * xi
+                                               for c, xi in zip(PRED_CODES, x))
+            pred = math.exp(pred_log)
+            for store, item in ((err_a4, "a4"), (err_d8, "d8")):
+                actual = rows[k].get(item)
+                if actual and actual > 0:
+                    store.append(abs(pred - actual) / actual)
+        ma4 = f"{np.median(err_a4) * 100:6.1f}%" if err_a4 else "   n/a"
+        md8 = f"{np.median(err_d8) * 100:6.1f}%" if err_d8 else "   n/a"
+        print(f"{y0:10s} -> {y1:10s} {ma4:>20s} {md8:>10s}")
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--csv", default=DEFAULT_CSV, help="path to stars_operations_allocation.csv")
+    ap.add_argument("--dep", default="a4", choices=list(DEPENDENTS),
+                    help="dependent variable for the per-year fit (default: a4)")
+    ap.add_argument("--report", action="store_true",
+                    help="run the full comparison across all dependent variables")
+    ap.add_argument("--predict-next", action="store_true",
+                    help="apply year-Y coefficients to year-(Y+1) inputs")
+    ap.add_argument("--coeffs", metavar="YEAR",
+                    help="recalculate and print coefficients for one year "
+                         "(e.g. 2023-2024) next to the published values")
+    ap.add_argument("--cost-csv", default=DEFAULT_COST_CSV,
+                    help="F-196 transit-expenditures CSV to use as the external "
+                         "(reported-cost) dependent variable")
+    ap.add_argument("--cost-data-type", default="actuals",
+                    help="data_type to keep from the cost CSV (default: actuals)")
+    ap.add_argument("--cost-ex-objects", default="0,1,9",
+                    help="comma-sep object_codes to exclude (default: 0,1,9 = "
+                         "Capital Outlay + Debit/Credit transfers)")
+    ap.add_argument("--cost-ex-activities", default="",
+                    help="comma-sep activity_codes to exclude (default: none)")
+    ap.add_argument("--cost-lag", type=int, default=0,
+                    help="join costs from class_of - LAG (0=same year, 1=prior year)")
+    args = ap.parse_args()
+
+    rows, published, raw_pred = load(args.csv)
+    print(f"Loaded {len(rows)} district-year records from {args.csv}")
+    print(f"Years: {', '.join(sorted({k[0] for k in rows}))}")
+
+    # Attach the external F-196 cost dependent if the file is available.
+    import os
+    if os.path.exists(args.cost_csv):
+        ex_obj = tuple(c for c in args.cost_ex_objects.split(",") if c)
+        ex_act = tuple(c for c in args.cost_ex_activities.split(",") if c)
+        totals, kept, dropped = load_costs(args.cost_csv, data_type=args.cost_data_type,
+                                           exclude_object_codes=ex_obj,
+                                           exclude_activity_codes=ex_act)
+        matched = attach_costs(rows, totals, lag=args.cost_lag)
+        print(f"Costs ({args.cost_data_type}, ex objects={ex_obj or None}, "
+              f"ex activities={ex_act or None}): {kept} rows kept, {dropped} dropped "
+              f"-> {len(totals)} district-years; matched to {matched} STARS "
+              f"records (lag={args.cost_lag})")
+    elif args.dep == "cost":
+        sys.exit(f"--dep cost requires --cost-csv (not found: {args.cost_csv})")
+
+    if args.coeffs:
+        show_coeffs(rows, published, args.coeffs, args.dep)
+        return
+
+    reconstruct(rows, raw_pred)
+    report(rows, published, args.dep)
+    if args.report:
+        report_all_deps(rows, published)
+    if args.predict_next or args.report:
+        predict_next(rows, published)
+
+
+if __name__ == "__main__":
+    main()

--- a/analysis/stars_mixed.md
+++ b/analysis/stars_mixed.md
@@ -1,0 +1,57 @@
+# District random-effects / partial-pooling model
+
+**Script:** `stars_mixed.py`
+
+## Purpose
+The "textbook" version of the fat-tail fix: a mixed model with a per-district
+random intercept, jointly estimated by REML. It is the generative model the
+credibility blend (`stars_credibility.md`) approximates in closed form.
+
+## Model
+```
+ln(cost_dy) = X_dy·beta + u_d + eps_dy ,   u_d ~ N(0, tau2),  eps ~ N(0, sigma2)
+```
+- (A) in-sample fit with **year fixed effects** (absorb each year's level).
+- (B) walk-forward forecast vs the *same model without the random effect* (pooled
+  OLS), isolating the partial-pooling contribution.
+
+## Key findings
+**(A) Structure:** ICC = **0.854** — *85% of the residual cost variance is
+persistent district identity*, only 15% year-to-year noise. The fat-tail miss is
+overwhelmingly a fixed per-district offset.
+
+BLUP offsets `u_d` (relative to the pooled fixed-effects):
+| district | u_d | implied |
+|---|---|---|
+| **Seattle** | +1.068 | **2.9×** formula |
+| Tacoma | +0.540 | 1.7× |
+| Renton | +0.508 | 1.7× |
+| Everett | −0.048 | ~1.0× |
+
+**(B) Forecast (RE vs no-RE, same year handling):**
+| sample | metric | pooled OLS | mixed +RE |
+|---|---|---|---|
+| All (n=839) | median / mean / 95th | 14.9% / 19.3% / 48.6% | **9.0% / 11.6% / 29.6%** |
+| Fat end (15) | median / mean / 95th | 22.0% / 25.8% / 57.5% | **11.0% / 13.3% / 29.9%** |
+
+RE wins 68% (all) / 75% (fat end). **SPS: 31%→4% (2019-20), 49%→21% (2024-25).**
+
+## Reconciliations
+- **τ² = 0.073 here vs 0.050 in the credibility run.** The credibility version fit
+  a fresh cross-section per year (year-specific coefficients absorbed more), while
+  this uses pooled coefficients + year fixed effects, so more structure surfaces as
+  the random intercept (hence SPS u_d +1.07 vs +0.48). ICC=0.85 is the
+  baseline-independent takeaway; forecast accuracy matches credibility.
+- **2022-23 is rough for both** (SPS still 48.5%) — the linear year-trend must
+  extrapolate the statewide level across the 2-year COVID gap. A level problem, not
+  the random effect.
+
+## Takeaway
+Confirms the diagnosis (85% persistent identity) and roughly halves fat-end error.
+**For production, ship the credibility blend** (more robust to the COVID-gap level
+issue) and cite this mixed model as its statistical justification.
+
+## Run
+```
+python3 analysis/stars_mixed.py
+```

--- a/analysis/stars_mixed.py
+++ b/analysis/stars_mixed.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Idea #1: district random-effects / partial-pooling model for STARS cost.
+
+    ln(cost_dy) = X_dy . beta  +  u_d  +  eps_dy ,   u_d ~ N(0, tau^2),  eps ~ N(0, sigma^2)
+
+A single REML fit over the whole panel estimates the shared STARS coefficients
+(beta), the between-district variance (tau^2) and within-district residual
+variance (sigma^2) jointly, and produces a partial-pooled (BLUP) intercept u_d
+for every district. u_d is the persistent offset the cross-sectional formula
+throws into its residual -- Seattle's ~+0.48, Everett's ~-0.58 -- shrunk toward 0
+by exactly the credibility factor. This is the generative model the closed-form
+credibility blend (stars_credibility.py) approximates; expect tau^2/sigma^2 here
+to match the credibility hyperparameters.
+
+Two reports:
+  (A) IN-SAMPLE structural fit with year fixed effects (each year's overall cost
+      level absorbed exactly, like the per-year collective). Shows variance
+      components, ICC, and the BLUP offsets for the fat-end districts.
+  (B) WALK-FORWARD forecast: for each target year Y, refit on prior non-COVID
+      years (linear year trend so it extrapolates), predict Y as
+      X.beta + u_d (BLUP from prior years only). Compared head-to-head with the
+      SAME model minus the random effect (pooled OLS), so the APE gap is purely
+      the partial-pooling contribution.
+
+Usage:
+    python3 analysis/stars_mixed.py
+    python3 analysis/stars_mixed.py --min-prior 2
+"""
+
+import argparse
+import importlib.util
+import math
+import os
+import warnings
+from collections import defaultdict
+
+import numpy as np
+import statsmodels.api as sm
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+COVID = {"2020-2021", "2021-2022"}
+warnings.filterwarnings("ignore")  # MixedLM convergence chatter
+
+
+def _se():
+    spec = importlib.util.spec_from_file_location(
+        "stars_exploration", os.path.join(HERE, "stars_exploration.py"))
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    return m
+
+
+def gather(se, rows):
+    """records: list of (ccddd, class_of_int, year_str, vec7, ln_cost), non-COVID."""
+    recs = []
+    for (sy, ccddd), rec in rows.items():
+        if sy in COVID:
+            continue
+        x = se.design_row(rec)
+        c = rec.get("cost")
+        if x is None or c is None or c <= 0:
+            continue
+        recs.append((ccddd, int(rec["class_of"]), sy, x, math.log(c), c))
+    return recs
+
+
+def fit_mixed(y, X, groups):
+    md = sm.MixedLM(y, X, groups=groups, exog_re=np.ones((len(y), 1)))
+    return md.fit(reml=True, method="lbfgs", maxiter=200)
+
+
+def district_names():
+    import csv
+    dn = {}
+    with open("out_stars/stars_operations_allocation.csv") as f:
+        for r in csv.DictReader(f):
+            dn[r["ccddd"]] = r["district"]
+    return dn
+
+
+def report_insample(se, recs, dn):
+    years = sorted({r[2] for r in recs})
+    ycol = {y: i for i, y in enumerate(years)}
+    # design: const + year dummies (drop first) + 7 predictors
+    X, y, groups = [], [], []
+    for ccddd, _c, sy, vec, lc, _cost in recs:
+        onehot = [1.0 if ycol[sy] == j else 0.0 for j in range(1, len(years))]
+        X.append([1.0] + onehot + vec)
+        y.append(lc)
+        groups.append(ccddd)
+    X = np.array(X); y = np.array(y)
+    res = fit_mixed(y, X, groups)
+    tau2 = float(np.asarray(res.cov_re)[0,0]); sigma2 = float(res.scale)
+    icc = tau2 / (tau2 + sigma2)
+    print("=== (A) In-sample random-intercept fit (year fixed effects) ===")
+    print(f"  observations={len(y)}  districts={len(set(groups))}")
+    print(f"  tau^2 (between-district) = {tau2:.4f}")
+    print(f"  sigma^2 (within-district) = {sigma2:.4f}")
+    print(f"  ICC = tau^2/(tau^2+sigma^2) = {icc:.3f}  "
+          f"({icc*100:.0f}% of residual cost variance is persistent district identity)")
+    print("  (compare to credibility hyperparameters tau^2~0.050, sigma^2~0.015)")
+    # fixed-effect STARS coefficients (last 7 columns)
+    fe = res.fe_params
+    coef_names = se.PRED_CODES
+    print("\n  Jointly-estimated STARS coefficients (pooled across all years):")
+    for nm, b in zip(coef_names, np.asarray(fe)[-7:]):
+        print(f"    {nm:18s} {b:+.4f}")
+    # BLUP offsets for fat-end districts
+    re = res.random_effects
+    size = defaultdict(list)
+    for ccddd, _c, _sy, _v, _lc, cost in recs:
+        size[ccddd].append(cost)
+    top = sorted(size, key=lambda c: np.mean(size[c]), reverse=True)[:15]
+    print("\n  Partial-pooled (BLUP) district offsets u_d, fat end "
+          "(positive = costs above formula):")
+    print(f"    {'district':34s} {'mean cost':>13s} {'u_d (BLUP)':>11s} {'~x dollars':>11s}")
+    for c in top:
+        u = float(np.asarray(re[c]).ravel()[0])
+        print(f"    {dn.get(c, c)[:34]:34s} {np.mean(size[c]):>13,.0f} "
+              f"{u:>+11.3f} {math.exp(u):>10.2f}x")
+    return tau2, sigma2
+
+
+def backtest(se, recs, dn, min_prior):
+    years = sorted({r[2] for r in recs})
+    by_year = defaultdict(list)
+    for r in recs:
+        by_year[r[2]].append(r)
+    # prior-year history count per district (non-COVID)
+    out = []
+    for i, sy in enumerate(years):
+        prior = years[:i]
+        if len(prior) < min_prior:
+            continue
+        prior_recs = [r for py in prior for r in by_year[py]]
+        prior_classes = [r[1] for r in prior_recs]
+        ybar = float(np.mean(prior_classes))
+        # design: const + yr_centered + 7 preds
+        Xp = np.array([[1.0, r[1] - ybar] + r[3] for r in prior_recs])
+        yp = np.array([r[4] for r in prior_recs])
+        grp = [r[0] for r in prior_recs]
+        hist_count = defaultdict(int)
+        for g in grp:
+            hist_count[g] += 1
+        mixed = fit_mixed(yp, Xp, grp)
+        ols = sm.OLS(yp, Xp).fit()
+        re = mixed.random_effects
+        fe = np.asarray(mixed.fe_params)
+        for ccddd, cls, _sy, vec, _lc, cost in by_year[sy]:
+            if hist_count.get(ccddd, 0) < min_prior or ccddd not in re:
+                continue
+            xnew = np.array([1.0, cls - ybar] + vec)
+            pred_re = math.exp(float(xnew @ fe) + float(np.asarray(re[ccddd]).ravel()[0]))
+            pred_no = math.exp(float(xnew @ ols.params))
+            out.append({
+                "ccddd": ccddd, "year": sy, "actual": cost,
+                "ape_re": abs(pred_re - cost) / cost,
+                "ape_no": abs(pred_no - cost) / cost,
+            })
+    return out
+
+
+def block(title, recs):
+    if not recs:
+        return
+    re = np.array([r["ape_re"] for r in recs])
+    no = np.array([r["ape_no"] for r in recs])
+    win = np.mean(re < no) * 100
+    print(f"\n{title}  (n={len(recs)})")
+    print(f"  {'':18s} {'median':>8s} {'mean':>8s} {'90th':>8s} {'95th':>8s}")
+    print(f"  {'pooled OLS (no RE)':18s} {np.median(no)*100:7.1f}% {np.mean(no)*100:7.1f}% "
+          f"{np.percentile(no,90)*100:7.1f}% {np.percentile(no,95)*100:7.1f}%")
+    print(f"  {'mixed (+ RE)':18s} {np.median(re)*100:7.1f}% {np.mean(re)*100:7.1f}% "
+          f"{np.percentile(re,90)*100:7.1f}% {np.percentile(re,95)*100:7.1f}%")
+    print(f"  random effect beats pooled on {win:.0f}% of district-years")
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--csv", default="out_stars/stars_operations_allocation.csv")
+    ap.add_argument("--cost-csv", default="transit-expenditures.csv")
+    ap.add_argument("--min-prior", type=int, default=2)
+    args = ap.parse_args()
+
+    se = _se()
+    rows, _pub, _raw = se.load(args.csv)
+    if not os.path.exists(args.cost_csv):
+        raise SystemExit(f"needs {args.cost_csv}")
+    totals, _k, _d = se.load_costs(args.cost_csv)
+    n = se.attach_costs(rows, totals, lag=0)
+    print(f"Attached F-196 cost (ex obj 0/1/9) to {n} district-years.\n")
+
+    recs = gather(se, rows)
+    dn = district_names()
+    report_insample(se, recs, dn)
+
+    print("\n=== (B) Walk-forward forecast: mixed (+RE) vs pooled OLS (no RE) ===")
+    bt = backtest(se, recs, dn, args.min_prior)
+    block("ALL evaluated district-years", bt)
+    size = defaultdict(list)
+    for r in bt:
+        size[r["ccddd"]].append(r["actual"])
+    top = set(sorted(size, key=lambda c: np.mean(size[c]), reverse=True)[:15])
+    block("FAT END (top 15 by mean cost)", [r for r in bt if r["ccddd"] in top])
+
+    sps = sorted([r for r in bt if r["ccddd"] == "17001"], key=lambda r: r["year"])
+    if sps:
+        print("\nSeattle Public Schools (17001) per target year:")
+        print(f"  {'year':10s} {'pooled APE':>11s} {'mixed APE':>11s}")
+        for r in sps:
+            print(f"  {r['year']:10s} {r['ape_no']*100:10.1f}% {r['ape_re']*100:10.1f}%")
+
+
+if __name__ == "__main__":
+    main()

--- a/analysis/stars_mixed_slope.md
+++ b/analysis/stars_mixed_slope.md
@@ -1,0 +1,54 @@
+# Random slope on basic_program
+
+**Script:** `stars_mixed_slope.py`
+
+## Purpose
+Extend the random-intercept model with a per-district random slope on
+`ln(basic_program)` (the dominant predictor), letting each district have its own
+ridership elasticity.
+
+## Model
+```
+ln(cost_dy) = X_dy·beta + u_d + v_d·(ln basic_program_dy − mean) + eps
+```
+`ln(basic_program)` is **centered** so the intercept (`u_d`) and slope (`v_d`) are
+not mechanically collinear. Compares random-intercept (RI) vs intercept+slope (RIS).
+
+## Key findings — significant in-sample, no forecast value
+**(A) In-sample:** LR test RIS vs RI = **39.4, p≈1.6e-9** — highly significant.
+Elasticity spread SD=0.071 around fixed β_basic=0.74. **Intercept–slope
+correlation = −0.69**: high-level districts have *flatter* cost-vs-ridership curves.
+
+| district | u_d (level) | v_d | total elasticity |
+|---|---|---|---|
+| **Seattle** | +1.177 | −0.157 | **0.582** |
+| Spokane | +0.507 | −0.097 | 0.643 |
+| Tacoma | +0.516 | −0.064 | 0.676 |
+| *typical* | ~0 | ~0 | **0.740** |
+
+→ Large urban systems have high *structural* cost but lower *marginal* cost per
+rider (**economies of scale**). The smooth version of the rural/urban interaction.
+
+**(B) Walk-forward:** RIS does **not** improve over RI — it slightly hurts.
+| | median | mean | 95th |
+|---|---|---|---|
+| RI | 9.0% | 11.6% | 29.6% |
+| RIS | 9.4% | 11.9% | 30.0% |
+
+RIS beats RI only 44% of the time; SPS gets *worse* in 3/4 years.
+
+## Why, and the verdict
+The slope is identified from **within-district ridership variation over a short
+(2–5 yr) panel**, which is tiny — so `v_d` overfits the training residuals (huge
+in-sample LR) but doesn't generalize. Same lesson as the rural-interaction F-test:
+**in-sample significance ≠ predictive value.**
+
+**Verdict: keep the random-intercept model for production.** The slope is worth
+reporting *descriptively* (urban economies of scale) but not for forecasting with
+this panel length. To make it pay off, pool the slope by district *type* (one urban,
+one rural slope) instead of per district — far fewer parameters, more stable.
+
+## Run
+```
+python3 analysis/stars_mixed_slope.py
+```

--- a/analysis/stars_mixed_slope.py
+++ b/analysis/stars_mixed_slope.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Random slope on basic_program: does each district need its own ridership elasticity?
+
+Extends the random-intercept model (stars_mixed.py) with a random slope on
+ln(basic_program), the dominant predictor:
+
+    ln(cost_dy) = X_dy . beta + u_d + v_d * (ln basic_program_dy - mean) + eps
+
+  u_d ~ district intercept (persistent level),  v_d ~ district-specific deviation
+  in the ridership elasticity. ln(basic_program) is CENTERED on its grand mean so
+  u_d and v_d are not mechanically collinear (intercept = effect at mean ridership).
+
+Compares random-intercept (RI) vs random-intercept+slope (RIS):
+  (A) in-sample: variance components, intercept/slope correlation, a REML
+      likelihood-ratio test (fixed effects identical, so the LRT on the 2 extra
+      random params is valid; boundary test => conservative), and the per-district
+      total elasticity (beta_basic + v_d) for the fat-end districts.
+  (B) walk-forward: does the random slope improve out-of-sample APE over RI?
+
+Caveat up front: a random slope is identified from WITHIN-district variation in
+ln(basic_program) over the ~6-year panel, which is modest. Expect it to be weakly
+identified -- the honest question is whether it earns its keep.
+
+Usage:
+    python3 analysis/stars_mixed_slope.py
+"""
+
+import argparse
+import importlib.util
+import math
+import os
+import warnings
+from collections import defaultdict
+
+import numpy as np
+import statsmodels.api as sm
+from scipy import stats
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+COVID = {"2020-2021", "2021-2022"}
+BASIC_IDX = 3   # position of basic_program in se.PRED_CODES
+warnings.filterwarnings("ignore")
+
+
+def _se():
+    spec = importlib.util.spec_from_file_location(
+        "stars_exploration", os.path.join(HERE, "stars_exploration.py"))
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    return m
+
+
+def gather(se, rows):
+    recs = []
+    for (sy, ccddd), rec in rows.items():
+        if sy in COVID:
+            continue
+        x = se.design_row(rec)
+        c = rec.get("cost")
+        if x is None or c is None or c <= 0:
+            continue
+        recs.append((ccddd, int(rec["class_of"]), sy, x, math.log(c), c))
+    return recs
+
+
+def fit(y, X, groups, re_exog):
+    md = sm.MixedLM(y, X, groups=groups, exog_re=re_exog)
+    return md.fit(reml=True, method="lbfgs", maxiter=300)
+
+
+def names():
+    import csv
+    dn = {}
+    with open("out_stars/stars_operations_allocation.csv") as f:
+        for r in csv.DictReader(f):
+            dn[r["ccddd"]] = r["district"]
+    return dn
+
+
+def insample(se, recs, dn):
+    years = sorted({r[2] for r in recs})
+    ycol = {y: i for i, y in enumerate(years)}
+    basic_mean = float(np.mean([r[3][BASIC_IDX] for r in recs]))
+    X, y, grp, bc = [], [], [], []
+    for ccddd, _c, sy, vec, lc, _cost in recs:
+        onehot = [1.0 if ycol[sy] == j else 0.0 for j in range(1, len(years))]
+        X.append([1.0] + onehot + vec)
+        y.append(lc); grp.append(ccddd)
+        bc.append(vec[BASIC_IDX] - basic_mean)
+    X = np.array(X); y = np.array(y); bc = np.array(bc)
+    ri = fit(y, X, grp, np.ones((len(y), 1)))
+    ris = fit(y, X, grp, np.column_stack([np.ones(len(y)), bc]))
+
+    cr = np.asarray(ris.cov_re)
+    v_int, v_slope, cov_is = cr[0, 0], cr[1, 1], cr[0, 1]
+    corr = cov_is / math.sqrt(v_int * v_slope) if v_int > 0 and v_slope > 0 else float("nan")
+    lr = 2 * (ris.llf - ri.llf)
+    # mixture chi2 for testing a variance + covariance on the boundary (df 1 & 2)
+    p = 0.5 * stats.chi2.sf(lr, 1) + 0.5 * stats.chi2.sf(lr, 2)
+
+    print("=== (A) In-sample: RI vs RI+slope(basic_program) ===")
+    print(f"  RI : tau^2(intercept)={np.asarray(ri.cov_re)[0,0]:.4f}  sigma^2={ri.scale:.4f}  llf={ri.llf:.1f}")
+    print(f"  RIS: var(intercept)={v_int:.4f}  var(slope)={v_slope:.5f}  "
+          f"corr(int,slope)={corr:+.2f}  sigma^2={ris.scale:.4f}  llf={ris.llf:.1f}")
+    print(f"  LR test (RIS vs RI): LR={lr:.1f}, mixture-chi2 p={p:.2e}  "
+          f"{'-> slope justified' if p < 0.05 else '-> slope NOT justified'}")
+    sd_slope = math.sqrt(v_slope) if v_slope > 0 else 0.0
+    beta_basic = float(np.asarray(ris.fe_params)[-7 + BASIC_IDX])
+    print(f"\n  Fixed elasticity beta_basic = {beta_basic:.3f}; district slopes SD = {sd_slope:.3f}")
+    print(f"  => ~95% of districts have ridership elasticity in "
+          f"[{beta_basic-2*sd_slope:.2f}, {beta_basic+2*sd_slope:.2f}]")
+
+    re = ris.random_effects
+    size = defaultdict(list)
+    for ccddd, _c, _sy, _v, _lc, cost in recs:
+        size[ccddd].append(cost)
+    top = sorted(size, key=lambda c: np.mean(size[c]), reverse=True)[:12]
+    print("\n  Fat-end districts: intercept u_d and total elasticity (beta_basic + v_d):")
+    print(f"    {'district':34s} {'u_d':>8s} {'v_d':>8s} {'elasticity':>11s}")
+    for c in top:
+        u, v = np.asarray(re[c]).ravel()[:2]
+        print(f"    {dn.get(c, c)[:34]:34s} {u:>+8.3f} {v:>+8.3f} {beta_basic+v:>11.3f}")
+    return basic_mean
+
+
+def backtest(se, recs, min_prior):
+    years = sorted({r[2] for r in recs})
+    by_year = defaultdict(list)
+    for r in recs:
+        by_year[r[2]].append(r)
+    out = []
+    for i, sy in enumerate(years):
+        prior = years[:i]
+        if len(prior) < min_prior:
+            continue
+        pr = [r for py in prior for r in by_year[py]]
+        ybar = float(np.mean([r[1] for r in pr]))
+        bmean = float(np.mean([r[3][BASIC_IDX] for r in pr]))
+        X = np.array([[1.0, r[1] - ybar] + r[3] for r in pr])
+        y = np.array([r[4] for r in pr])
+        grp = [r[0] for r in pr]
+        bc = np.array([r[3][BASIC_IDX] - bmean for r in pr])
+        hist = defaultdict(int)
+        for g in grp:
+            hist[g] += 1
+        ri = fit(y, X, grp, np.ones((len(y), 1)))
+        ris = fit(y, X, grp, np.column_stack([np.ones(len(y)), bc]))
+        re_ri, re_ris = ri.random_effects, ris.random_effects
+        fe_ri, fe_ris = np.asarray(ri.fe_params), np.asarray(ris.fe_params)
+        for ccddd, cls, _sy, vec, _lc, cost in by_year[sy]:
+            if hist.get(ccddd, 0) < min_prior or ccddd not in re_ri:
+                continue
+            xnew = np.array([1.0, cls - ybar] + vec)
+            p_ri = math.exp(float(xnew @ fe_ri) + float(np.asarray(re_ri[ccddd]).ravel()[0]))
+            uv = np.asarray(re_ris[ccddd]).ravel()
+            p_ris = math.exp(float(xnew @ fe_ris) + uv[0] + uv[1] * (vec[BASIC_IDX] - bmean))
+            out.append({"ccddd": ccddd, "year": sy, "actual": cost,
+                        "ape_ri": abs(p_ri - cost) / cost,
+                        "ape_ris": abs(p_ris - cost) / cost})
+    return out
+
+
+def block(title, recs):
+    if not recs:
+        return
+    ri = np.array([r["ape_ri"] for r in recs])
+    ris = np.array([r["ape_ris"] for r in recs])
+    print(f"\n{title}  (n={len(recs)})")
+    print(f"  {'':22s} {'median':>8s} {'mean':>8s} {'90th':>8s} {'95th':>8s}")
+    print(f"  {'RI (intercept only)':22s} {np.median(ri)*100:7.1f}% {np.mean(ri)*100:7.1f}% "
+          f"{np.percentile(ri,90)*100:7.1f}% {np.percentile(ri,95)*100:7.1f}%")
+    print(f"  {'RIS (+ basic slope)':22s} {np.median(ris)*100:7.1f}% {np.mean(ris)*100:7.1f}% "
+          f"{np.percentile(ris,90)*100:7.1f}% {np.percentile(ris,95)*100:7.1f}%")
+    print(f"  RIS beats RI on {np.mean(ris < ri)*100:.0f}% of district-years")
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--csv", default="out_stars/stars_operations_allocation.csv")
+    ap.add_argument("--cost-csv", default="transit-expenditures.csv")
+    ap.add_argument("--min-prior", type=int, default=2)
+    args = ap.parse_args()
+
+    se = _se()
+    rows, _pub, _raw = se.load(args.csv)
+    totals, _k, _d = se.load_costs(args.cost_csv)
+    n = se.attach_costs(rows, totals, lag=0)
+    print(f"Attached F-196 cost to {n} district-years.\n")
+
+    recs = gather(se, rows)
+    insample(se, recs, names())
+    print("\n=== (B) Walk-forward: RI vs RIS ===")
+    bt = backtest(se, recs, args.min_prior)
+    block("ALL evaluated district-years", bt)
+    size = defaultdict(list)
+    for r in bt:
+        size[r["ccddd"]].append(r["actual"])
+    top = set(sorted(size, key=lambda c: np.mean(size[c]), reverse=True)[:15])
+    block("FAT END (top 15 by mean cost)", [r for r in bt if r["ccddd"] in top])
+    sps = sorted([r for r in bt if r["ccddd"] == "17001"], key=lambda r: r["year"])
+    if sps:
+        print("\nSeattle Public Schools (17001) per target year:")
+        print(f"  {'year':10s} {'RI APE':>9s} {'RIS APE':>9s}")
+        for r in sps:
+            print(f"  {r['year']:10s} {r['ape_ri']*100:8.1f}% {r['ape_ris']*100:8.1f}%")
+
+
+if __name__ == "__main__":
+    main()

--- a/analysis/stars_poly_forecast.md
+++ b/analysis/stars_poly_forecast.md
@@ -1,0 +1,43 @@
+# Per-district polynomial forecast vs STARS
+
+**Script:** `stars_poly_forecast.py`
+
+## Purpose
+Test whether extrapolating a district's *own* allocation history with a low-order
+polynomial predicts next year's allocation as well as OSPI's full route-data
+formula — and characterize where each method wins.
+
+## Method
+For target year Y and window k: fit a polynomial (degree 1 = linear, or
+min(k−1, 2)) to the district's own `D.8` over years Y−k…Y−1 and extrapolate to Y.
+Benchmark = STARS `A.4` expected allocation. Ground truth = `D.8` actual.
+Scored by absolute % error (APE) on the same district-years (paired).
+
+## Key findings (non-COVID, level-space linear — the best variant)
+| window | poly median APE | poly mean APE | STARS median | STARS mean | poly win rate |
+|---|---|---|---|---|---|
+| 2 yr | 12.9% | 17.8% | 8.6% | 21.3% | 44.5% |
+| 3 yr | 13.2% | 18.1% | 8.5% | 21.9% | 44.4% |
+| 4 yr | 15.7% | 19.6% | 8.5% | 21.9% | 39.3% |
+| 5 yr | 16.9% | 18.5% | 8.5% | 21.9% | 40.5% |
+
+- **By median, STARS wins** (~8.5% vs ~13%) — the route formula is ~1.5× more
+  accurate for the typical district.
+- **By mean, the polynomial wins** (~18% vs ~22%) — STARS has a **fatter tail of
+  large misses**; anchoring to a district's own history avoids the blowups.
+- The polynomial is closer than STARS on ~44% of district-years.
+- **Shorter window is better** (2–3 yr); **higher degree is worse** (quadratic
+  oscillates); **log-space is worse** than level (amplifies trends).
+
+## Takeaway
+A linear extrapolation of 2–3 years of a district's own allocations gets within
+~13% with fewer catastrophic errors, but OSPI's formula is more accurate for the
+typical district. Value of the history method = a **robustness check / outlier
+flag**, not a replacement. This motivated the credibility/partial-pooling work
+(`stars_credibility.md`, `stars_mixed.md`) that fuses both.
+
+## Run
+```
+python3 analysis/stars_poly_forecast.py
+python3 analysis/stars_poly_forecast.py --log --windows 2,3,4,5
+```

--- a/analysis/stars_poly_forecast.py
+++ b/analysis/stars_poly_forecast.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Per-district polynomial forecast of the transportation allocation, benchmarked
+against the existing STARS cross-sectional formula.
+
+Question: instead of OSPI's formula -- which each year regresses every district's
+allocation on freshly-collected route/geography characteristics (land area,
+ridership, programs, ...) -- could you predict a district's next-year allocation
+just by extrapolating its OWN recent allocation history with a low-order
+polynomial in time? And is that more or less accurate than STARS?
+
+Setup for a target year Y and a window of k prior years:
+  * POLYNOMIAL method: fit a degree-d polynomial to (year, D.8) over the k years
+    Y-k .. Y-1 for that district, then evaluate it at Y. Uses ONLY that
+    district's own allocation history -- no route data, no cross-district info.
+        d = 1            -> linear trend (robust)
+        d = min(k-1, 2)  -> "poly": quadratic once >= 3 points are available
+  * STARS method: A.4 "initial/expected allocation" for year Y, i.e. the formula
+    output already in the ledger. (Uses year-Y route characteristics + the
+    regression coefficients.)
+  * GROUND TRUTH: D.8 actual allocation amount for year Y.
+
+Both are scored by absolute percentage error vs the same D.8 actual, on the SAME
+set of district-years, so "more/less accurate" is a paired comparison. The
+sample necessarily shrinks as k grows (need k prior years of history).
+
+Usage:
+    python3 analysis/stars_poly_forecast.py
+    python3 analysis/stars_poly_forecast.py --target d8 --log
+    python3 analysis/stars_poly_forecast.py --windows 2,3,4,5 --max-degree 2
+"""
+
+import argparse
+import importlib.util
+import os
+from collections import defaultdict
+
+import numpy as np
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+COVID_TARGET_YEARS = {2021, 2022}  # school years 2020-21, 2021-22
+
+
+def load_series(stars_csv):
+    """Return {ccddd: {class_of_int: {'d8':.., 'a4':..}}} via the exploration loader."""
+    spec = importlib.util.spec_from_file_location(
+        "stars_exploration", os.path.join(HERE, "stars_exploration.py"))
+    se = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(se)
+    rows, _published, _raw = se.load(stars_csv)
+    series = defaultdict(dict)
+    for (_sy, ccddd), rec in rows.items():
+        co = rec.get("class_of")
+        if co is None:
+            continue
+        series[ccddd][int(co)] = {"d8": rec.get("d8"), "a4": rec.get("a4")}
+    return series
+
+
+def poly_forecast(years, values, target_year, degree, log_space):
+    """Fit a degree-`degree` polynomial through (years, values) and extrapolate to
+    target_year. Years are centered for numerical stability. In log_space the fit
+    is on ln(values) and the result is exponentiated."""
+    x = np.array(years, dtype=float) - years[0]
+    y = np.array(values, dtype=float)
+    if log_space:
+        if np.any(y <= 0):
+            return None
+        y = np.log(y)
+    deg = min(degree, len(years) - 1)
+    coeffs = np.polyfit(x, y, deg)
+    pred = np.polyval(coeffs, target_year - years[0])
+    if log_space:
+        pred = np.exp(pred)
+    return float(pred)
+
+
+def ape(pred, actual):
+    if pred is None or actual is None or actual <= 0:
+        return None
+    return abs(pred - actual) / actual
+
+
+def evaluate(series, window, degree, target, log_space):
+    """Collect paired (poly_ape, stars_ape) over every predictable district-year
+    for the given window. Returns a list of dict records."""
+    recs = []
+    for ccddd, yrs in series.items():
+        for Y in yrs:
+            hist_years = list(range(Y - window, Y))
+            if not all(h in yrs and yrs[h][target] is not None for h in hist_years):
+                continue
+            actual = yrs[Y]["d8"]
+            stars_pred = yrs[Y]["a4"]
+            if actual is None or stars_pred is None:
+                continue
+            hist_vals = [yrs[h][target] for h in hist_years]
+            poly_pred = poly_forecast(hist_years, hist_vals, Y, degree, log_space)
+            pa, sa = ape(poly_pred, actual), ape(stars_pred, actual)
+            if pa is None or sa is None:
+                continue
+            recs.append({"ccddd": ccddd, "year": Y, "poly_ape": pa, "stars_ape": sa})
+    return recs
+
+
+def summarize(recs, drop_covid):
+    if drop_covid:
+        recs = [r for r in recs if r["year"] not in COVID_TARGET_YEARS]
+    n = len(recs)
+    if n == 0:
+        return None
+    poly = np.array([r["poly_ape"] for r in recs])
+    stars = np.array([r["stars_ape"] for r in recs])
+    win = np.mean(poly < stars)
+    return {
+        "n": n,
+        "poly_med": np.median(poly) * 100,
+        "poly_mean": np.mean(poly) * 100,
+        "stars_med": np.median(stars) * 100,
+        "stars_mean": np.mean(stars) * 100,
+        "win_rate": win * 100,
+    }
+
+
+def run(series, windows, max_degree, target, log_space, drop_covid):
+    label = "excluding COVID target years (2021,2022)" if drop_covid else "all target years"
+    space = "log-space" if log_space else "level"
+    print(f"\n=== Polynomial forecast vs STARS  [target={target.upper()}, "
+          f"{space} fit, {label}] ===")
+    print("APE = absolute % error vs D.8 actual. Win = % of district-years where "
+          "polynomial beats STARS.\n")
+    hdr = (f"{'window':>6} {'degree':>6} {'n':>5} "
+           f"{'POLY medAPE':>12} {'POLY meanAPE':>13} "
+           f"{'STARS medAPE':>13} {'STARS meanAPE':>14} {'POLY win%':>10}")
+    print(hdr)
+    print("-" * len(hdr))
+    for k in windows:
+        for deg in sorted({1, min(k - 1, max_degree)}):
+            recs = evaluate(series, k, deg, target, log_space)
+            s = summarize(recs, drop_covid)
+            if s is None:
+                continue
+            tag = "linear" if deg == 1 else f"deg{deg}"
+            print(f"{k:>6} {tag:>6} {s['n']:>5} "
+                  f"{s['poly_med']:>11.1f}% {s['poly_mean']:>12.1f}% "
+                  f"{s['stars_med']:>12.1f}% {s['stars_mean']:>13.1f}% "
+                  f"{s['win_rate']:>9.1f}%")
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--stars-csv", default="out_stars/stars_operations_allocation.csv")
+    ap.add_argument("--windows", default="2,3,4,5",
+                    help="comma-sep prior-year window sizes (default 2,3,4,5)")
+    ap.add_argument("--max-degree", type=int, default=2,
+                    help="cap polynomial degree (default 2 = quadratic)")
+    ap.add_argument("--target", default="d8", choices=["d8", "a4"],
+                    help="history series to extrapolate (default d8 actual allocation)")
+    ap.add_argument("--log", action="store_true",
+                    help="fit in log space (multiplicative trend)")
+    args = ap.parse_args()
+
+    series = load_series(args.stars_csv)
+    windows = [int(w) for w in args.windows.split(",") if w]
+    print(f"Loaded {len(series)} districts, "
+          f"{sum(len(v) for v in series.values())} district-years.")
+
+    # Report both with and without the COVID-distorted target years.
+    for drop in (False, True):
+        run(series, windows, args.max_degree, args.target, args.log, drop)
+
+
+if __name__ == "__main__":
+    main()

--- a/analysis/stars_rural_interaction.md
+++ b/analysis/stars_rural_interaction.md
@@ -1,0 +1,43 @@
+# Rural/urban indicator + input interactions
+
+**Script:** `stars_rural_interaction.py`
+
+## Purpose
+Ask the structural question: do rural and urban districts have **different cost
+structures**? Add a rural/urban dummy and interact it with every continuous input
+so each slope (elasticity) can differ, then joint-F-test the interaction block.
+
+## Method
+Rural = bottom 50% by density (`basic_program/land_area`), split per year. Model
+adds `rural` + `rural × {land_area, average_distance, destinations, basic_program,
+special_program}`. Dependent = F-196 cost. `a4` = negative control.
+
+## Key findings
+Cost target, jointly significant in **4 of 6** non-COVID years (ΔR² 0.0009–0.0045).
+
+**Critical caveat — trust ΔR², not the F-test:** the `a4` negative control is
+"significant" at p<1e-5 in **7/7** years *despite ΔR² ≈ 0*. When base R² ≈ 0.9998,
+residual variance is so tiny that microscopic curvature reads as highly
+significant. By the honest metric, cost gains ~0.3–0.45% — **~30× the control** —
+so it's real but small.
+
+Interpretable slope differences (2018-19):
+| interaction | coef | p | meaning |
+|---|---|---|---|
+| rural × land_area | +0.100 | 0.023 | land area drives cost rurally, ~nil urban |
+| rural × destinations | +0.017 | 0.012 | destinations matter more rurally |
+| rural × special_program | −0.117 | 0.020 | special-ed scales less steeply rurally |
+
+Geography is the cost driver in rural districts; ridership counts dominate urban.
+
+## Takeaway
+A genuine but **small** structural difference (<0.5% added R²) — it won't move the
+coefficient-recovery floor. The policy-relevant consequence (the single statewide
+formula's residuals are biased by district identity) is pursued in
+`stars_credibility.md` and `stars_mixed.md`.
+
+## Run
+```
+python3 analysis/stars_rural_interaction.py
+python3 analysis/stars_rural_interaction.py --dep a4   # negative control
+```

--- a/analysis/stars_rural_interaction.py
+++ b/analysis/stars_rural_interaction.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Add a rural/urban indicator to the STARS model and test input interactions.
+
+Rather than asking whether ruralness adds a little signal (it didn't, as a single
+density term), this asks the structural question: do rural and urban districts
+have DIFFERENT cost structures? We split districts into rural vs urban, add the
+dummy as a main effect, and interact it with each continuous input so every
+slope (elasticity) is free to differ between the two groups:
+
+    ln(cost) = [7 base STARS predictors]
+             + rural
+             + rural * ln(land_area)
+             + rural * average_distance
+             + rural * destinations
+             + rural * ln(basic_program)
+             + rural * ln(special_program)
+
+The key statistic is a joint F-test of the whole added block (dummy + 5
+interactions) against the base model, per year: if it's significant, the
+rural/urban distinction genuinely reshapes how inputs map to cost.
+
+Rural/urban split (data-driven, no external locale codes available):
+  density = basic_program / land_area (students per sq mi). Within each year,
+  districts below the chosen quantile of density are 'rural' (low density). The
+  split is per-year so it stays balanced as the panel changes. Threshold is
+  configurable; --split inverse uses land_area/basic_program instead.
+
+Dependent: F-196 reported cost (default; the real target). dep=a4 is a negative
+control -- the formula output has no rural structure, so the block should be ~0.
+
+Usage:
+    python3 analysis/stars_rural_interaction.py
+    python3 analysis/stars_rural_interaction.py --quantile 0.33 --dep cost
+    python3 analysis/stars_rural_interaction.py --dep a4         # negative control
+"""
+
+import argparse
+import importlib.util
+import math
+import os
+
+import numpy as np
+import statsmodels.api as sm
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+COVID = {"2020-2021", "2021-2022"}
+# continuous inputs whose slope we let vary by rural/urban (transformed as in base)
+INTERACT = ["land_area", "average_distance", "destinations",
+            "basic_program", "special_program"]
+
+
+def _se():
+    spec = importlib.util.spec_from_file_location(
+        "stars_exploration", os.path.join(HERE, "stars_exploration.py"))
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    return m
+
+
+def density(rec, split):
+    area = rec.get("land_area")
+    basic = rec.get("basic_program")
+    if area is None or area <= 0 or basic is None or basic <= 0:
+        return None
+    return area / basic if split == "inverse" else basic / area
+
+
+def year_design(se, rows, sy, dep, quantile, split):
+    """Build base X, extended X (with rural dummy + interactions), y, and the
+    transformed-feature index map for one year. Returns None if too few rows."""
+    # collect usable records and their density
+    recs = []
+    for k in [k for k in rows if k[0] == sy]:
+        rec = rows[k]
+        base = se.design_row(rec)
+        d = density(rec, split)
+        yv = rec.get(dep)
+        if base is None or d is None or yv is None or yv <= 0:
+            continue
+        recs.append((base, d, math.log(yv)))
+    if len(recs) < 30:
+        return None
+    dens = np.array([r[1] for r in recs])
+    cut = np.quantile(dens, quantile)
+    # 'rural' = low density (for inverse split, high value = rural, so flip)
+    if split == "inverse":
+        cut = np.quantile(dens, 1 - quantile)
+        rural = (dens >= cut).astype(float)
+    else:
+        rural = (dens < cut).astype(float)
+
+    idx = {c: i for i, c in enumerate(se.PRED_CODES)}
+    Xb, Xe = [], []
+    for (base, _d, _y), R in zip(recs, rural):
+        Xb.append(base)
+        inter = [R * base[idx[c]] for c in INTERACT]
+        Xe.append(base + [R] + inter)
+    y = np.array([r[2] for r in recs])
+    return np.array(Xb), np.array(Xe), y, int(rural.sum()), len(recs)
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--csv", default="out_stars/stars_operations_allocation.csv")
+    ap.add_argument("--cost-csv", default="transit-expenditures.csv")
+    ap.add_argument("--dep", default="cost", choices=["cost", "a4", "d8", "d4"])
+    ap.add_argument("--quantile", type=float, default=0.5,
+                    help="density quantile cut for rural (default 0.5 = median split)")
+    ap.add_argument("--split", default="density", choices=["density", "inverse"])
+    ap.add_argument("--detail-year", default="2018-2019",
+                    help="year to print the full interaction breakdown for")
+    args = ap.parse_args()
+
+    se = _se()
+    rows, _pub, _raw = se.load(args.csv)
+    if args.dep == "cost":
+        if not os.path.exists(args.cost_csv):
+            raise SystemExit(f"--dep cost needs {args.cost_csv}")
+        totals, _k, _d = se.load_costs(args.cost_csv)
+        n = se.attach_costs(rows, totals, lag=0)
+        print(f"Attached F-196 cost (ex obj 0/1/9) to {n} district-years.")
+
+    print(f"\nRural = bottom {args.quantile:.0%} by density "
+          f"({'land_area/basic' if args.split=='inverse' else 'basic/land_area'}), "
+          f"per-year split. dep={args.dep}.")
+    print("Joint F-test: rural dummy + 5 slope interactions vs base model.\n")
+    print(f"{'year':10s} {'n':>4s} {'rural':>5s} {'R2 base':>8s} {'R2 ext':>8s} "
+          f"{'dR2':>7s} {'F(6)':>7s} {'p':>8s} {'sig':>4s}")
+    years = sorted({k[0] for k in rows})
+    sig = tested = 0
+    for sy in years:
+        if sy in COVID:
+            continue
+        built = year_design(se, rows, sy, args.dep, args.quantile, args.split)
+        if built is None:
+            continue
+        Xb, Xe, y, nr, n = built
+        rb = sm.OLS(y, sm.add_constant(Xb)).fit()
+        re = sm.OLS(y, sm.add_constant(Xe)).fit()
+        F, p, _df = re.compare_f_test(rb)
+        tested += 1
+        s = "***" if p < 0.01 else ("**" if p < 0.05 else ("*" if p < 0.10 else ""))
+        if p < 0.05:
+            sig += 1
+        print(f"{sy:10s} {n:4d} {nr:5d} {rb.rsquared:8.4f} {re.rsquared:8.4f} "
+              f"{re.rsquared-rb.rsquared:7.4f} {F:7.2f} {p:8.4f} {s:>4s}")
+    print(f"\n  interaction block jointly significant (p<0.05): {sig}/{tested} years")
+
+    # full breakdown for one representative year
+    built = year_design(se, rows, args.detail_year, args.dep, args.quantile, args.split)
+    if built is not None:
+        Xb, Xe, y, nr, n = built
+        re = sm.OLS(y, sm.add_constant(Xe)).fit()
+        names = (["const"] + se.PRED_CODES + ["rural"]
+                 + [f"rural*{c}" for c in INTERACT])
+        print(f"\nFull extended model, {args.detail_year} (n={n}, rural={nr}, "
+              f"R2={re.rsquared:.4f}):")
+        print(f"{'term':22s} {'coef':>11s} {'t':>7s} {'p':>7s}")
+        for nm, b, t, p in zip(names, re.params, re.tvalues, re.pvalues):
+            star = "*" if p < 0.05 else " "
+            print(f"{nm:22s} {b:11.4f} {t:7.2f} {p:7.3f}{star}")
+
+
+if __name__ == "__main__":
+    main()

--- a/analysis/stars_ruralness.md
+++ b/analysis/stars_ruralness.md
@@ -1,0 +1,33 @@
+# Ruralness density term
+
+**Script:** `stars_ruralness.py`
+
+## Purpose
+Test whether a single "ruralness" indicator — population density
+(`basic_program / land_area`) — adds explanatory power to the STARS model.
+
+## Key modelling note
+The base model already has `ln(land_area)` and `ln(basic_program)`, so adding
+`ln(density) = ln(basic_program) − ln(land_area)` would be a **perfect linear
+combination** of existing terms (singular). Density therefore must enter in
+**level/ratio form** to carry new information.
+
+## Key findings
+Dependent = F-196 cost (real target):
+- ΔR² ≈ **0.0001–0.0002** per year; density **never significant** (0/8 years,
+  p ≥ 0.22); AIC mostly *worsens*.
+- `a4` negative control: ΔR² ≈ 0 (as expected — `a4` is a pure function of the 7
+  inputs), confirming the test is wired correctly.
+
+## Takeaway
+A single density term adds essentially nothing. Ruralness is already captured by
+the inputs the formula has — `average_distance` (long routes = rural) plus the
+size terms. This is a **null result**; the structural question (do rural and urban
+districts have *different* cost structures?) is answered separately and more
+usefully in `stars_rural_interaction.md`.
+
+## Run
+```
+python3 analysis/stars_ruralness.py            # dep=cost
+python3 analysis/stars_ruralness.py --dep a4   # negative control
+```

--- a/analysis/stars_ruralness.py
+++ b/analysis/stars_ruralness.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Extend the STARS log-linear model with a 'ruralness' density predictor and
+test whether it adds explanatory power.
+
+Ruralness proxy: density = population / land_area, where the population proxy is
+the basic-transportation ridership (`basic_program`, the closest student-count in
+the STARS ledger). Low density = few students spread over a large area = rural.
+
+IMPORTANT modelling note. The base STARS model already contains ln(land_area)
+and ln(basic_program). Adding ln(density) = ln(basic_program) - ln(land_area)
+would be an exact linear combination of those two regressors -> perfect
+collinearity, zero new information, singular design. So density MUST enter in
+LEVEL (ratio) form, which is a genuinely new nonlinear transform. This script
+adds `density` (raw) on top of the 7 base predictors.
+
+Dependent variable matters:
+  * dep=a4  -> A.4 expected allocation is, by construction, an exact function of
+               the 7 base predictors. Density therefore CANNOT help (delta-R^2 ~ 0,
+               t ~ 0). Useful as a negative control / sanity check.
+  * dep=cost-> F-196 reported transportation cost (the real-world target). This is
+               where an omitted ruralness effect could actually show up.
+
+Reports, per year: base vs extended R^2, the density coefficient with its t-stat
+and p-value, and the change in adjusted R^2 / AIC.
+
+Usage:
+    python3 analysis/stars_ruralness.py                 # dep=cost (default)
+    python3 analysis/stars_ruralness.py --dep a4        # negative control
+    python3 analysis/stars_ruralness.py --pop total     # basic+special ridership
+"""
+
+import argparse
+import importlib.util
+import math
+import os
+
+import numpy as np
+import statsmodels.api as sm
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+COVID_YEARS = {"2020-2021", "2021-2022"}
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location(
+        "stars_exploration", os.path.join(HERE, "stars_exploration.py"))
+    se = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(se)
+    return se
+
+
+def density(rec, pop):
+    """population / land_area in level form. pop='basic' uses basic_program;
+    pop='total' uses basic+special program ridership."""
+    area = rec.get("land_area")
+    basic = rec.get("basic_program")
+    special = rec.get("special_program") or 0.0
+    if area is None or area <= 0 or basic is None:
+        return None
+    population = basic + (special if pop == "total" else 0.0)
+    return population / area
+
+
+def build(se, rows, sy, dep, pop):
+    """Return (X_base, X_ext, y) numpy arrays for one school year, or None.
+    X_base is the 7 STARS predictors (with the usual transforms); X_ext appends
+    the level-form density column."""
+    Xb, Xe, y = [], [], []
+    spec = se.DEPENDENTS[dep]
+    for k in [k for k in rows if k[0] == sy]:
+        rec = rows[k]
+        base = se.design_row(rec)          # 7 transformed predictors
+        dval = density(rec, pop)
+        yv = rec.get(dep)
+        if base is None or dval is None or yv is None:
+            continue
+        if spec["logged"]:
+            yval = yv
+        else:
+            if yv <= 0:
+                continue
+            yval = math.log(yv)
+        Xb.append(base)
+        Xe.append(base + [dval])
+        y.append(yval)
+    if len(y) < 25:
+        return None
+    return np.array(Xb), np.array(Xe), np.array(y)
+
+
+def fit(X, y):
+    return sm.OLS(y, sm.add_constant(X)).fit()
+
+
+def run(se, rows, dep, pop, drop_covid):
+    label = "ex-COVID" if drop_covid else "all years"
+    print(f"\n=== Ruralness (density = {pop}_ridership / land_area, level form) "
+          f"added to STARS  [dep={dep}, {label}] ===")
+    print(f"{'year':10s} {'n':>4s} {'R2 base':>8s} {'R2 ext':>8s} {'dR2':>7s} "
+          f"{'adjR2 b':>8s} {'adjR2 e':>8s} {'dens coef':>11s} {'t':>7s} "
+          f"{'p':>7s} {'dAIC':>8s}")
+    years = sorted({k[0] for k in rows})
+    dr2s, ts, sig = [], [], 0
+    for sy in years:
+        if drop_covid and sy in COVID_YEARS:
+            continue
+        built = build(se, rows, sy, dep, pop)
+        if built is None:
+            continue
+        Xb, Xe, y = built
+        rb, re = fit(Xb, y), fit(Xe, y)
+        dcoef = re.params[-1]      # density is the last column after const+7
+        dt = re.tvalues[-1]
+        dp = re.pvalues[-1]
+        dr2 = re.rsquared - rb.rsquared
+        daic = re.aic - rb.aic
+        dr2s.append(dr2); ts.append(dt)
+        if dp < 0.05:
+            sig += 1
+        star = "*" if dp < 0.05 else " "
+        print(f"{sy:10s} {len(y):4d} {rb.rsquared:8.4f} {re.rsquared:8.4f} "
+              f"{dr2:7.4f} {rb.rsquared_adj:8.4f} {re.rsquared_adj:8.4f} "
+              f"{dcoef:11.3e} {dt:7.2f} {dp:7.3f}{star}{daic:7.1f}")
+    if dr2s:
+        n = len(dr2s)
+        print(f"\n  years tested: {n} | density significant (p<0.05): {sig}/{n} | "
+              f"mean dR2: {np.mean(dr2s):+.4f} | mean t: {np.mean(ts):+.2f}")
+        print("  (dAIC<0 favors the extended model; dR2 is the gain in raw R^2)")
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--csv", default="out_stars/stars_operations_allocation.csv")
+    ap.add_argument("--cost-csv", default="transit-expenditures.csv")
+    ap.add_argument("--dep", default="cost", choices=["cost", "a4", "a3", "d8", "d2"])
+    ap.add_argument("--pop", default="basic", choices=["basic", "total"],
+                    help="population proxy: basic_program, or basic+special ridership")
+    args = ap.parse_args()
+
+    se = _load_module()
+    rows, _pub, _raw = se.load(args.csv)
+    if args.dep == "cost":
+        if not os.path.exists(args.cost_csv):
+            raise SystemExit(f"--dep cost needs {args.cost_csv}")
+        totals, _k, _d = se.load_costs(args.cost_csv)
+        matched = se.attach_costs(rows, totals, lag=0)
+        print(f"Attached F-196 cost (ex obj 0/1/9) to {matched} district-years.")
+
+    for drop in (False, True):
+        run(se, rows, args.dep, args.pop, drop)
+
+
+if __name__ == "__main__":
+    main()

--- a/analysis/stars_target_timing.md
+++ b/analysis/stars_target_timing.md
@@ -1,0 +1,42 @@
+# Cost target & timing — which dependent reproduces the coefficients
+
+**Script:** `stars_target_timing.py`
+
+## Purpose
+The expected-allocation regression is calibrated to predicted *cost*. Determine
+which cost series, at which timing, best reproduces the published STARS
+coefficients — in particular whether OSPI's own "adjusted prior-year expenditures"
+(`D.4`), aligned to the adjacent year, is the right dependent.
+
+## Candidates
+- **`D.4`** adjusted prior-year expenditures (= `D.2` + `D.3` federal indirects);
+  the basis of the `D.5` cap. A year-(Y−1) quantity → pair with adjacent-year inputs.
+- **`D.2`** raw prior-year expenditures.
+- **F-196** reconstructed cost (same-year), the baseline.
+
+## Key findings (mean max |recovered − published| coef diff, non-COVID)
+| target / timing | vs that year | vs next year |
+|---|---|---|
+| `A.4` formula output (circular control) | 0.029 | — |
+| **F-196 cost, same-year (baseline)** | **0.192** | **0.175** |
+| `D.4` adj prior-yr exp, contemporaneous | 0.295 | 0.275 |
+| `D.4` adj prior-yr exp, as-stored lag | 0.241 | — |
+| `D.2` prior-yr exp, contemporaneous | 0.333 | 0.342 |
+
+- **`D.4` is *worse* than F-196 in every timing**, despite being OSPI's own number.
+  Reason: `D.4 = D.2 + D.3`, and `D.3` (federal restricted-rate indirects) is
+  district-specific administrative noise the route regression can't explain.
+- The **"apply next year" timing** is weakly better than same-year (0.175 vs
+  0.192); 2024-25 cost vs 2025-26 published coefs = **0.027** (near-exact).
+- **Nothing breaks below a ~0.17 floor.** The floor is the *estimator*, not the
+  target.
+
+## Takeaway
+Regressing on adjusted prior-year expenditures does **not** help; same-year (or
+apply-next-year) F-196 cost remains the best target. To close the residual gap,
+fix the estimator (weighting / outlier trimming), not the dependent variable.
+
+## Run
+```
+python3 analysis/stars_target_timing.py
+```

--- a/analysis/stars_target_timing.py
+++ b/analysis/stars_target_timing.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Which cost target + timing best reproduces the published STARS coefficients?
+
+The expected-allocation regression is calibrated to predicted COST. The question
+is which cost series, at which lag, recovers the published coefficients:
+
+  * D.4 "adjusted prior-year expenditures" is OSPI's OWN cost number, already in
+    the ledger (= D.2 + D.3 federal indirects) and the basis of the D.5 cap.
+    Critically D.4 in year Y's record is the year-(Y-1) expenditure, so it must
+    be paired with the ADJACENT (prior) year's predictors to be contemporaneous.
+  * D.2 raw prior-year expenditures (same one-year lag).
+  * F-196 reconstructed cost (external, same-year) -- the earlier baseline.
+
+For a fit indexed by predictor-year c we regress  ln(dep[c + dep_lag]) ~ X[c]
+and compare the recovered coefficients to the PUBLISHED coefficients of year c
+(the formula coefficients that sit alongside X[c]). dep_lag=+1 pulls the
+dependent from the NEXT record, which for a prior-year quantity like D.4/D.2
+makes cost and predictors describe the SAME real year.
+
+Alignment cheat-sheet (c = predictor year):
+  dep=d4 dep_lag=0  ->  D.4[c]   = cost of year c-1  vs X[c]      (mismatched)
+  dep=d4 dep_lag=+1 ->  D.4[c+1] = cost of year c    vs X[c]      (contemporaneous)
+  dep=cost dep_lag=0 -> F196[c]  = cost of year c    vs X[c]      (contemporaneous)
+
+Usage:
+    python3 analysis/stars_target_timing.py
+"""
+
+import importlib.util
+import math
+import os
+from collections import defaultdict
+
+import numpy as np
+import statsmodels.api as sm
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+COVID = {"2020-2021", "2021-2022"}
+
+
+def _se():
+    spec = importlib.util.spec_from_file_location(
+        "stars_exploration", os.path.join(HERE, "stars_exploration.py"))
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    return m
+
+
+def fit_aligned(se, rows, by_year, sy, dep, dep_lag):
+    """Regress ln(dep[c+dep_lag]) ~ X[c] for predictor-year sy. Returns coef dict
+    or None. by_year maps class_of(int) -> {ccddd: rec}."""
+    try:
+        c = int(rows_year_to_class(rows, sy))
+    except Exception:
+        return None
+    src = by_year.get(c + dep_lag, {})
+    X, y = [], []
+    for ccddd, rec in by_year.get(c, {}).items():
+        x = se.design_row(rec)
+        if x is None:
+            continue
+        drec = src.get(ccddd)
+        if drec is None:
+            continue
+        dv = drec.get(dep)
+        if dv is None or dv <= 0:
+            continue
+        X.append(x)
+        y.append(math.log(dv))
+    if len(y) < 25:
+        return None
+    res = sm.OLS(np.array(y), sm.add_constant(np.array(X))).fit()
+    coef = {"intercept": res.params[0]}
+    for j, code in enumerate(se.PRED_CODES):
+        coef[code] = res.params[j + 1]
+    return coef, len(y), res.rsquared
+
+
+def rows_year_to_class(rows, sy):
+    for (s, _c), rec in rows.items():
+        if s == sy:
+            return rec["class_of"]
+    raise KeyError(sy)
+
+
+def maxdiff(se, coef, pub):
+    keys = ["intercept"] + se.PRED_CODES
+    d = [abs(coef[k] - pub[k]) for k in keys if k in pub]
+    return max(d) if d else float("nan")
+
+
+def main():
+    se = _se()
+    rows, published, _ = se.load("out_stars/stars_operations_allocation.csv")
+    # attach F196 cost (same-year) as the 'cost' dependent baseline
+    if os.path.exists("transit-expenditures.csv"):
+        totals, _k, _d = se.load_costs("transit-expenditures.csv")
+        se.attach_costs(rows, totals, lag=0)
+
+    # index records by class_of year
+    by_year = defaultdict(dict)
+    sy_of_class = {}
+    for (sy, ccddd), rec in rows.items():
+        c = int(rec["class_of"])
+        by_year[c][ccddd] = rec
+        sy_of_class[c] = sy
+
+    configs = [
+        ("d4", +1, "D.4 adj prior-yr exp, contemporaneous (X[c] vs cost-of-c)"),
+        ("d4", 0,  "D.4 adj prior-yr exp, as-stored   (X[c] vs cost-of-c-1)"),
+        ("d2", +1, "D.2 prior-yr exp, contemporaneous (X[c] vs cost-of-c)"),
+        ("cost", 0, "F-196 reconstructed cost, same-year (baseline)"),
+        ("a4", 0,  "A.4 expected allocation (formula output; self-consistency)"),
+    ]
+
+    years = sorted({k[0] for k in rows})
+    print("Mean (over non-COVID predictor-years) of max|recovered - published| coef diff,")
+    print("comparing each recovered fit to the published coefficients of predictor-year c.\n")
+    print(f"{'dependent / timing':58s} {'years':>5s} {'meanR2':>7s} {'mean maxdiff':>13s}")
+    print("-" * 86)
+    for dep, lag, label in configs:
+        diffs, r2s = [], []
+        for sy in years:
+            if sy in COVID:
+                continue
+            out = fit_aligned(se, rows, by_year, sy, dep, lag)
+            if out is None or sy not in published:
+                continue
+            coef, n, r2 = out
+            diffs.append(maxdiff(se, coef, published[sy]))
+            r2s.append(r2)
+        if diffs:
+            print(f"{label:58s} {len(diffs):5d} {np.mean(r2s):7.3f} {np.mean(diffs):13.4f}")
+
+    # Test the "fit on year-c cost, apply NEXT year" framing: compare the
+    # contemporaneous-cost fit (year-c cost vs year-c predictors) to the published
+    # coefficients of year c+1, not year c.
+    nextyear = {c: sy_of_class.get(c + 1) for c in by_year}
+    print("\n'Fit on year-c cost, applied year c+1' test:")
+    print("mean max|recovered - published[c+1]| over non-COVID years:")
+    for dep, lag, label in [("d4", 1, "D.4 (=cost of c)"),
+                            ("d2", 1, "D.2 (=cost of c)"),
+                            ("cost", 0, "F-196 cost of c")]:
+        diffs = []
+        for sy in years:
+            if sy in COVID:
+                continue
+            c = int(rows_year_to_class(rows, sy))
+            nsy = nextyear.get(c)
+            out = fit_aligned(se, rows, by_year, sy, dep, lag)
+            if out and nsy in published:
+                diffs.append(maxdiff(se, out[0], published[nsy]))
+        if diffs:
+            print(f"   {label:20s} vs pub[c+1]: {np.mean(diffs):.4f}  (n={len(diffs)})")
+
+    # per-year detail, both comparison targets
+    print("\nPer-year max-diff (non-COVID).  d4+1 = D.4 contemporaneous fit:")
+    print(f"{'pred-yr c':10s} {'d4+1 vs pub[c]':>15s} {'d4+1 vs pub[c+1]':>17s} "
+          f"{'cost vs pub[c]':>15s} {'cost vs pub[c+1]':>17s}")
+    for sy in years:
+        if sy in COVID:
+            continue
+        c = int(rows_year_to_class(rows, sy))
+        nsy = nextyear.get(c)
+        d4 = fit_aligned(se, rows, by_year, sy, "d4", 1)
+        co = fit_aligned(se, rows, by_year, sy, "cost", 0)
+        def cell(out, target):
+            return f"{maxdiff(se, out[0], published[target]):.4f}" if out and target in published else "   -"
+        print(f"{sy:10s} {cell(d4, sy):>15s} {cell(d4, nsy):>17s} "
+              f"{cell(co, sy):>15s} {cell(co, nsy):>17s}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Exploratory analysis of OSPI's STARS pupil-transportation operations allocation formula: reproduce the per-year log-linear regression, probe alternative predictors/targets, diagnose the persistent fat-tail bias for large systems (e.g. Seattle), and prototype credibility / mixed-effects fixes.

Eight models, each with a companion .md summary and an index README:
- stars_exploration       reproduce the Section A log-linear regression
- stars_poly_forecast     per-district history extrapolation vs STARS
- stars_ruralness         density predictor (null result)
- stars_target_timing     which cost target/timing recovers the coefficients
- stars_rural_interaction rural/urban indicator + input interactions
- stars_credibility       Buhlmann credibility blend (deployable fat-tail fix)
- stars_mixed             district random-intercept model (ICC 0.85)
- stars_mixed_slope       random slope on basic_program (no OOS value)