### PR TITLE
bigsheet: publish static inputs as BigQuery external tables

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,16 @@ The same schema dict is converted to SQLAlchemy `Table` (via `orm.py:make_table`
 
 ### Marts
 
+**FROZEN as of 2026-07-25:** `bigsheet` now lives in the website repo as a
+BigQuery Cloud Function (`sps-by-the-numbers-website/functions/src/bigsheet/`,
+see that repo's `BIGSHEET_MIGRATION_PLAN.md`). The SQL reproduces this script's
+Seattle output value-for-value (golden diff clean). `marts/bigsheet.py`,
+`vitals.sql`, `assessment.sql` are kept unchanged as the golden-regression
+source. The seven `data/sps` static inputs are published to BigQuery external
+tables via `scripts/publish_bigsheet_inputs.sh` + `create_bigsheet_input_tables.sh`;
+re-run both whenever those CSVs change, then bump `BIGSHEET_SQL_VERSION` in the
+website.
+
 `marts/bigsheet.py` is a first-class pipeline stage (a data mart built on
 extractor outputs): it joins ALL per-school data we have — enrollment and
 demographics, per-program spend, S-275 staffing/salary/experience, MAP

--- a/marts/README.md
+++ b/marts/README.md
@@ -5,6 +5,23 @@ together, as opposed to `extractors/`, which ingest a single source each.
 
 ## `bigsheet.py`
 
+> **FROZEN — provenance only (2026-07-25).** `bigsheet` has been migrated to the
+> website repo as a BigQuery Cloud Function that builds one SQL string and
+> exports DEFLATE AVRO: `sps-by-the-numbers-website/functions/src/bigsheet/`
+> (see `BIGSHEET_MIGRATION_PLAN.md` there for the full record). The SQL
+> reproduces this script's Seattle output **value-for-value** (golden diff:
+> 1185 rows × 1240 cols, 0 mismatches). `bigsheet.py`, `vitals.sql` and
+> `assessment.sql` are kept UNCHANGED as the golden-regression source of truth
+> and reference; do not delete (owner's call). Regenerate the golden with
+> `venv/bin/python3 -m marts.bigsheet -o reference/regress/bigsheet_golden_seattle.csv`.
+>
+> The seven static inputs under `data/sps/{map,building,s275,sqss}/` are
+> published to BigQuery external tables by `scripts/publish_bigsheet_inputs.sh`
+> + `scripts/create_bigsheet_input_tables.sh`. **Whenever those CSVs change,
+> re-run both scripts and then bump `BIGSHEET_SQL_VERSION` in the website
+> (`functions/src/bigsheet/assemble.ts`)** — the export cache does NOT
+> auto-invalidate on CSV content changes (only on pivot-combo changes).
+
 Joins **all the per-school data this repo has** into one wide table: one row
 per school per cohort year, ~1,240 columns. Enrollment and demographics,
 per-pupil spend by program, S-275 staffing/salary/experience, MAP scores,

--- a/scripts/bigsheet_inputs_lib.py
+++ b/scripts/bigsheet_inputs_lib.py
@@ -1,0 +1,201 @@
+"""Shared logic for publishing the bigsheet static inputs as BigQuery
+external tables (website functions/src/bigsheet migration, task T0.2).
+
+Two consumers:
+  - publish_bigsheet_inputs.sh  -> build_staging(): writes the seven CSVs to a
+    staging dir (slim + `_csv_row`-indexed for the three pivot-order-sensitive
+    inputs; verbatim for the four pass-through inputs).
+  - create_bigsheet_input_tables.sh -> emit_ddl(): prints CREATE OR REPLACE
+    EXTERNAL TABLE statements with explicit schemas.
+
+`sanitizeName` MUST stay byte-identical to functions/src/bigsheet/names.ts:
+every run of non-[A-Za-z0-9_] -> single '_'; prefix '_' if it starts with a
+digit. (No trailing-underscore stripping -- the golden-diff harness applies the
+same rule to the golden headers, so any transform here must match there.)
+"""
+import re
+import shutil
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+GCS_PREFIX = 'gs://sps-by-the-numbers-public/static/bigsheet-inputs'
+DATASET = 'sps-btn-data.bigsheet_inputs'
+DATA = Path('data/sps')
+
+
+def sanitize_name(raw):
+    s = re.sub(r'[^A-Za-z0-9_]+', '_', str(raw))
+    if s and s[0].isdigit():
+        s = '_' + s
+    return s
+
+
+# ---- The three pivot-order-sensitive inputs: slim + _csv_row -----------------
+# _csv_row is the 0-based pd.read_csv row index, i.e. the physical CSV order the
+# pandas pivot sees. Column order below IS the external-table schema order.
+
+def _slim_map_hc():
+    df = pd.read_csv(DATA / 'map/map-score-2017-2024-average-hc.csv')
+    out = pd.DataFrame({
+        'school_code': df['school_code'],
+        'grade': df['grade'],
+        'season': df['season'],
+        'academic_subject': df['AcademicSubject'],
+        'avg_rit_score': df['Average of RITScore'],
+        'stddev_rit_score': df['StdDev of RITScore'],
+    })
+    return out
+
+
+def _slim_map_nonhc():
+    df = pd.read_csv(DATA / 'map/map-score-2017-2024-average-nonhc.csv')
+    out = pd.DataFrame({
+        'school_code': df['school_code'],
+        'grade': df['Grade'],
+        'season': df['Season'],
+        'academic_subject': df['MAP Academic Subject'],
+        'avg_rit_score': df['Average RIT Score'],
+        'stddev': df['Std Deviation'],
+        'number_of_students': df['Number of Students'],
+    })
+    return out
+
+
+def _slim_sqss():
+    df = pd.read_csv(DATA / 'sqss/sqss.csv')
+    out = pd.DataFrame({
+        'class_of': df['class_of'],
+        'school_code': df['school_code'],
+        'student_group': df['student_group'],
+        'measure': df['measure'],
+        'percent': df['percent'],
+        'numerator': df['numerator'],
+        'denominator': df['denominator'],
+    })
+    return out
+
+
+# schema for the slim tables: (name, bq_type); _csv_row prepended in build.
+SLIM = {
+    'map_hc': (_slim_map_hc, [
+        ('school_code', 'INT64'), ('grade', 'INT64'), ('season', 'STRING'),
+        ('academic_subject', 'STRING'), ('avg_rit_score', 'FLOAT64'),
+        ('stddev_rit_score', 'FLOAT64')]),
+    # nonhc value columns carry suppression markers ("n<10"), so pandas reads
+    # them as object -> the golden keeps the raw strings. Type them STRING; the
+    # golden diff compares numerically-with-tolerance for the numeric cells.
+    'map_nonhc': (_slim_map_nonhc, [
+        ('school_code', 'INT64'), ('grade', 'INT64'), ('season', 'STRING'),
+        ('academic_subject', 'STRING'), ('avg_rit_score', 'STRING'),
+        ('stddev', 'STRING'), ('number_of_students', 'STRING')]),
+    'sqss': (_slim_sqss, [
+        ('class_of', 'INT64'), ('school_code', 'INT64'),
+        ('student_group', 'STRING'), ('measure', 'STRING'),
+        ('percent', 'FLOAT64'), ('numerator', 'FLOAT64'),
+        ('denominator', 'FLOAT64')]),
+}
+
+
+# ---- The four pass-through inputs: copied verbatim ---------------------------
+# (src basename under data/sps, published basename, explicit schema in file
+# column order). Pass-through schema names for bex use sanitize_name(header) so
+# a `SELECT * EXCEPT(school_code)` in the generator yields golden-matching
+# names. FLOAT64 unless pandas inferred object/str (see bigsheet.py golden).
+
+_BEX_SRC = 'building/bex-vi-historic-building-scores.csv'
+_BEX_STRING_COLS = {'Last Major Update', 'Scope of Work'}
+
+
+def _bex_schema():
+    header = pd.read_csv(DATA / _BEX_SRC, nrows=0).columns.tolist()
+    schema = []
+    for h in header:
+        if h == 'school_code':
+            schema.append(('school_code', 'INT64'))
+        else:
+            t = 'STRING' if h in _BEX_STRING_COLS else 'FLOAT64'
+            schema.append((sanitize_name(h), t))
+    return schema
+
+
+PASSTHROUGH = {
+    'bex': ('building/bex-vi-historic-building-scores.csv', _bex_schema),
+    'utilization_condition': ('building/utilization_condition.csv', lambda: [
+        ('school_code', 'INT64'), ('pct_2025_utilization', 'FLOAT64'),
+        ('pct_building_condition', 'FLOAT64'),
+        ('learning_environment_score', 'FLOAT64'),
+        ('_2022_building_condition_score', 'FLOAT64')]),
+    'income_by_school': ('building/income_by_school.csv', lambda: [
+        ('es_zone', 'STRING'), ('school_code', 'INT64'),
+        ('area_worker_earnings_median', 'FLOAT64'),
+        ('area_percapita_income', 'FLOAT64')]),
+    'building_transitions': ('s275/building_transitions.csv', lambda: [
+        ('class_of', 'INT64'), ('duty_root', 'INT64'),
+        ('school_code', 'INT64'), ('transfer_in', 'INT64'),
+        ('school', 'STRING'), ('duty_name', 'STRING'),
+        ('duty_name_category', 'STRING'), ('transfer_out', 'INT64'),
+        ('hire', 'INT64'), ('depart', 'INT64')]),
+}
+
+
+def table_schema(table):
+    """Full ordered [(name, type), ...] incl. _csv_row for slim tables."""
+    if table in SLIM:
+        return [('_csv_row', 'INT64')] + SLIM[table][1]
+    return PASSTHROUGH[table][1]()
+
+
+ALL_TABLES = list(SLIM) + list(PASSTHROUGH)
+
+
+# Columns that must serialize as clean integers (a stray NaN elsewhere in the
+# source can otherwise coerce the whole column to float -> "2138.0", which
+# fails INT64 parsing on the external table). pandas nullable Int64 writes
+# "2138" and "" (for NaN).
+_INT_COLS = {'school_code', 'grade', 'class_of', '_csv_row'}
+
+
+def build_staging(staging_dir):
+    staging = Path(staging_dir)
+    staging.mkdir(parents=True, exist_ok=True)
+    for name, (fn, _schema) in SLIM.items():
+        df = fn().reset_index(drop=True)
+        df.insert(0, '_csv_row', range(len(df)))
+        for c in df.columns:
+            if c in _INT_COLS:
+                df[c] = df[c].astype('Int64')
+        df.to_csv(staging / f'{name}.csv', index=False)
+        print(f'  built slim {name}.csv ({len(df)} rows, +_csv_row)')
+    for name, (src, _schema) in PASSTHROUGH.items():
+        # Byte-for-byte copy: a pandas round-trip would coerce INT columns that
+        # carry a stray NaN to float ("1.0"), which fails INT64 parsing.
+        shutil.copyfile(DATA / src, staging / f'{name}.csv')
+        n = sum(1 for _ in open(DATA / src)) - 1
+        print(f'  copied {name}.csv ({n} rows) from {src}')
+
+
+def emit_ddl():
+    lines = [f'CREATE SCHEMA IF NOT EXISTS `{DATASET}`;', '']
+    for table in ALL_TABLES:
+        cols = ',\n  '.join(f'`{n}` {t}' for n, t in table_schema(table))
+        uri = f'{GCS_PREFIX}/{table}.csv'
+        lines.append(
+            f'CREATE OR REPLACE EXTERNAL TABLE `{DATASET}.{table}` (\n'
+            f'  {cols}\n'
+            f') OPTIONS (\n'
+            f"  format = 'CSV',\n"
+            f"  uris = ['{uri}'],\n"
+            f'  skip_leading_rows = 1\n'
+            f');\n')
+    return '\n'.join(lines)
+
+
+if __name__ == '__main__':
+    if len(sys.argv) > 1 and sys.argv[1] == 'ddl':
+        print(emit_ddl())
+    elif len(sys.argv) > 2 and sys.argv[1] == 'stage':
+        build_staging(sys.argv[2])
+    else:
+        sys.exit('usage: bigsheet_inputs_lib.py ddl | stage <dir>')

--- a/scripts/create_bigsheet_input_tables.sh
+++ b/scripts/create_bigsheet_input_tables.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#
+# Create (or replace) the sps-btn-data.bigsheet_inputs external tables that back
+# the migrated bigsheet SQL. Idempotent; safe to re-run after republishing the
+# CSVs with scripts/publish_bigsheet_inputs.sh.
+#
+# The dataset is created in the SAME location as ospi/safs_* (us-west1) so
+# cross-dataset joins and EXPORT DATA to the public bucket work.
+#
+# Run from the data-tools repo root:  scripts/create_bigsheet_input_tables.sh
+set -euo pipefail
+
+LOCATION="us-west1"
+DDL_FILE="reference/scratch/bigsheet_inputs.ddl.sql"
+
+mkdir -p "$(dirname "$DDL_FILE")"
+venv/bin/python3 scripts/bigsheet_inputs_lib.py ddl > "$DDL_FILE"
+
+echo "== DDL =="
+cat "$DDL_FILE"
+echo
+echo "== Running in location $LOCATION =="
+bq --project_id=sps-btn-data query --use_legacy_sql=false --location="$LOCATION" < "$DDL_FILE"
+
+echo
+echo "== Verifying external tables (row counts) =="
+for t in map_hc map_nonhc sqss bex utilization_condition income_by_school building_transitions; do
+  n=$(bq --project_id=sps-btn-data query --use_legacy_sql=false --location="$LOCATION" \
+        --format=csv "SELECT COUNT(*) FROM \`sps-btn-data.bigsheet_inputs.$t\`" | tail -1)
+  printf '  %-24s %s rows\n' "$t" "$n"
+done

--- a/scripts/publish_bigsheet_inputs.sh
+++ b/scripts/publish_bigsheet_inputs.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#
+# Publish the seven bigsheet static inputs to the public cache bucket as CSVs
+# that back BigQuery external tables in sps-btn-data.bigsheet_inputs
+# (see marts/bigsheet.py migration -> website functions/src/bigsheet).
+#
+# Run from the data-tools repo root:  scripts/publish_bigsheet_inputs.sh
+#
+# NOTE: the export cache does NOT auto-invalidate when these CSV contents change
+# (only pivot-combo changes invalidate it). After re-running this script, BUMP
+# BIGSHEET_SQL_VERSION in the website (functions/src/bigsheet/assemble.ts).
+set -euo pipefail
+
+BUCKET_PREFIX="gs://sps-by-the-numbers-public/static/bigsheet-inputs"
+STAGING="reference/scratch/bigsheet-inputs"
+
+echo "== Privacy check =="
+echo "All seven inputs are school-level (or building/area-level) AGGREGATES:"
+echo "  map_hc/map_nonhc     : per-school average/stddev RIT scores"
+echo "  bex/utilization/income: per-building condition/utilization/area income"
+echo "  building_transitions : per-(class_of,school) staff counts"
+echo "  sqss                 : per-(school,group) percentages/counts"
+echo "None contain individual-person rows. If that ever changes, STOP."
+echo
+
+echo "== Building staging CSVs in $STAGING =="
+rm -rf "$STAGING"
+venv/bin/python3 scripts/bigsheet_inputs_lib.py stage "$STAGING"
+
+echo
+echo "== Uploading to $BUCKET_PREFIX =="
+gsutil -m cp "$STAGING"/*.csv "$BUCKET_PREFIX/"
+
+echo
+echo "== Verifying headers =="
+for t in map_hc map_nonhc sqss bex utilization_condition income_by_school building_transitions; do
+  printf '  %-24s ' "$t.csv:"
+  gsutil cat "$BUCKET_PREFIX/$t.csv" | head -1
+done
+echo
+echo "Done. Remember to (re)run scripts/create_bigsheet_input_tables.sh and,"
+echo "if contents changed, bump BIGSHEET_SQL_VERSION in the website."


### PR DESCRIPTION
Part of the bigsheet migration to the website repo (SQL Cloud Function).

- scripts/bigsheet_inputs_lib.py + publish_bigsheet_inputs.sh + create_bigsheet_input_tables.sh: publish the seven data/sps static inputs (MAP hc/nonhc, BEX, utilization, income, building_transitions, SQSS) to sps-btn-data.bigsheet_inputs external tables (us-west1). The three pivot-order-sensitive inputs get a slim + _csv_row-indexed CSV so BigQuery can reproduce pandas' physical-row-order pivot column ordering; the four pass-through inputs are byte-copied with explicit schemas.
- marts/README.md + CLAUDE.md: mark marts/bigsheet.py + vitals.sql + assessment.sql frozen as the golden-regression source; note the republish + BIGSHEET_SQL_VERSION-bump workflow.

Golden diff (website functions/scripts/golden_diff.ts) is clean: 1185 rows x 1240 cols, 0 value mismatches.